### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/common/core/domainToRegexp.ts
+++ b/src/common/core/domainToRegexp.ts
@@ -32,3 +32,41 @@ export function domainToRegexp(domain: string): HandlerMatch {
 export function match(domain: string, handler: HandlerMatch): boolean {
   return handler.regexp.test(domain);
 }
+
+/**
+ * When presented with a domain name that contains a wildcard, and a label want to apply to it,
+ * this function will handle replacing the wildcard with the label and return the full domain name.
+ * 
+ * Example:
+ * - `resolveWildcards('sub', '*.example.com')` returns `sub.example.com`
+ * - `resolveWildcards('sub', 'example.com')` returns `example.com`
+ * - `resolveWildcards('second.sub', '*.example.com')` returns `second.sub.example.com`
+ * 
+ * Note that by convention, wildcards are only supported on the first label of the domain. Any other
+ * wildcards will be treated as a literal `*` character.
+ * 
+ * Example:
+ * - `resolveWildcards('sub', '*.example.*.com')` returns `sub.example.*.com`
+ * 
+ * Also note that this function will attempt to correct for any leading separators, likely due to
+ * attempting to replace a wildcard with an empty string. Since each domain label is expected to be
+ * non-empty, this function will consider an empty label to be equivalent to removal of the subdomain
+ * altogether.
+ * 
+ * @param incomingLabel 
+ * @param domainWildcard 
+ */
+export function resolveWildcards(
+  incomingLabel: string,
+  domainWildcard: string
+) {
+  const parts = domainWildcard.split('.');
+  if (parts[0] === '*') {
+    if (incomingLabel === '') {
+      parts.shift();
+    } else {
+      parts[0] = incomingLabel;
+    }
+  }
+  return parts.join('.');
+}

--- a/src/common/core/domainToRegexp.ts
+++ b/src/common/core/domainToRegexp.ts
@@ -36,30 +36,27 @@ export function match(domain: string, handler: HandlerMatch): boolean {
 /**
  * When presented with a domain name that contains a wildcard, and a label want to apply to it,
  * this function will handle replacing the wildcard with the label and return the full domain name.
- * 
+ *
  * Example:
  * - `resolveWildcards('sub', '*.example.com')` returns `sub.example.com`
  * - `resolveWildcards('sub', 'example.com')` returns `example.com`
  * - `resolveWildcards('second.sub', '*.example.com')` returns `second.sub.example.com`
- * 
+ *
  * Note that by convention, wildcards are only supported on the first label of the domain. Any other
  * wildcards will be treated as a literal `*` character.
- * 
+ *
  * Example:
  * - `resolveWildcards('sub', '*.example.*.com')` returns `sub.example.*.com`
- * 
+ *
  * Also note that this function will attempt to correct for any leading separators, likely due to
  * attempting to replace a wildcard with an empty string. Since each domain label is expected to be
  * non-empty, this function will consider an empty label to be equivalent to removal of the subdomain
  * altogether.
- * 
- * @param incomingLabel 
- * @param domainWildcard 
+ *
+ * @param incomingLabel
+ * @param domainWildcard
  */
-export function resolveWildcards(
-  incomingLabel: string,
-  domainWildcard: string
-) {
+export function resolveWildcards(incomingLabel: string, domainWildcard: string) {
   const parts = domainWildcard.split('.');
   if (parts[0] === '*') {
     if (incomingLabel === '') {

--- a/src/common/core/utils.spec.ts
+++ b/src/common/core/utils.spec.ts
@@ -1,4 +1,4 @@
-import { resolveWildcards, domainToRegexp } from './domainToRegexp';
+import { resolveWildcards } from './domainToRegexp';
 
 describe('resolveWildcards', () => {
   test('replaces single wildcard', () => {

--- a/src/common/core/utils.spec.ts
+++ b/src/common/core/utils.spec.ts
@@ -1,0 +1,56 @@
+import { resolveWildcards, domainToRegexp } from './domainToRegexp';
+
+describe('resolveWildcards', () => {
+  test('replaces single wildcard', () => {
+    expect(resolveWildcards('sub', '*.example.com')).toBe('sub.example.com');
+  });
+
+  test('no wildcard present', () => {
+    expect(resolveWildcards('sub', 'example.com')).toBe('example.com');
+  });
+
+  test('replaces leftmost wildcard if more than one are present', () => {
+    expect(resolveWildcards('second.sub', '*.example.*.com')).toBe('second.sub.example.*.com');
+  });
+
+  test('empty wildcard replacement', () => {
+    expect(resolveWildcards('', '*.example.com')).toBe('example.com');
+  });
+
+  test('replaces leftmost adjacent wildcard in input string', () => {
+    expect(resolveWildcards('sub', '*.*.example.com')).toBe('sub.*.example.com');
+  });
+
+  test('does not attempt to replace a wildcard located anywhere other than the leftmost part of the string', () => {
+    expect(resolveWildcards('sub', 'example.*.com')).toBe('example.*.com');
+  });
+
+  test('does not attempt to replace a wildcard at the end of the string', () => {
+    expect(resolveWildcards('sub', 'example.com.*')).toBe('example.com.*');
+  });
+
+  test('wildcard with numeric values', () => {
+    expect(resolveWildcards('123', '*.example.com')).toBe('123.example.com');
+  });
+});
+
+// describe('domainToRegexp', () => {
+//   test('converts domain with no wildcard', () => {
+//     const handler = domainToRegexp('example.com');
+//     expect(handler.regexp.test('example.com')).toBe(true);
+//     expect(handler.regexp.test('sub.example.com')).toBe(false);
+//   });
+
+//   test('converts domain with single wildcard', () => {
+//     const handler = domainToRegexp('*.example.com');
+//     expect(handler.regexp.test('sub.example.com')).toBe(true);
+//     expect(handler.regexp.test('example.com')).toBe(false);
+//   });
+
+//   test('converts domain with multiple records', () => {
+//     const handler = domainToRegexp('example.com/A|MX');
+//     expect(handlfer.regexp.test('example.com/A')).toBe(true);
+//     expect(handler.regexp.test('example.com/MX')).toBe(true);
+//     expect(handler.regexp.test('example.com/TXT')).toBe(false);
+//   });
+// });

--- a/src/common/store/trieStore.spec.ts
+++ b/src/common/store/trieStore.spec.ts
@@ -85,7 +85,7 @@ describe('AnswerTrie', () => {
   });
 
   it('Should be able to resolve wildcard queries', () => {
-    trie.add('*.example.com', 'A', records);
+    trie.add('*.example.com', 'A', records.map(r => ({ ...r, name: '*.example.com' })));
     const subRecords = records.map((record) => {
       return {
         ...record,
@@ -96,7 +96,7 @@ describe('AnswerTrie', () => {
   });
 
   it('Should be able to resolve wildcard queries with multiple labels', () => {
-    trie.add('*.example.com', 'A', records);
+    trie.add('*.example.com', 'A', records.map(r => ({ ...r, name: '*.example.com' })));
     const subRecords = records.map((record) => {
       return {
         ...record,
@@ -120,8 +120,8 @@ describe('AnswerTrie', () => {
 
   it('Should be able to deserialie and serialize the trie', () => {
     trie.add('example.com', 'A', records);
-    trie.add('*.example.com', 'A', records);
-    trie.add('*.sub.example.com', 'A', records);
+    trie.add('*.example.com', 'A', records.map(r => ({ ...r, name: '*.example.com' })));
+    trie.add('*.sub.example.com', 'A', records.map(r => ({ ...r, name: '*.sub.example.com' })));
 
     const serialized = trie.toString();
     const deserialized = AnswerTrie.fromString(serialized);

--- a/src/common/store/trieStore.spec.ts
+++ b/src/common/store/trieStore.spec.ts
@@ -85,7 +85,11 @@ describe('AnswerTrie', () => {
   });
 
   it('Should be able to resolve wildcard queries', () => {
-    trie.add('*.example.com', 'A', records.map(r => ({ ...r, name: '*.example.com' })));
+    trie.add(
+      '*.example.com',
+      'A',
+      records.map((r) => ({ ...r, name: '*.example.com' })),
+    );
     const subRecords = records.map((record) => {
       return {
         ...record,
@@ -96,7 +100,11 @@ describe('AnswerTrie', () => {
   });
 
   it('Should be able to resolve wildcard queries with multiple labels', () => {
-    trie.add('*.example.com', 'A', records.map(r => ({ ...r, name: '*.example.com' })));
+    trie.add(
+      '*.example.com',
+      'A',
+      records.map((r) => ({ ...r, name: '*.example.com' })),
+    );
     const subRecords = records.map((record) => {
       return {
         ...record,
@@ -120,8 +128,16 @@ describe('AnswerTrie', () => {
 
   it('Should be able to deserialie and serialize the trie', () => {
     trie.add('example.com', 'A', records);
-    trie.add('*.example.com', 'A', records.map(r => ({ ...r, name: '*.example.com' })));
-    trie.add('*.sub.example.com', 'A', records.map(r => ({ ...r, name: '*.sub.example.com' })));
+    trie.add(
+      '*.example.com',
+      'A',
+      records.map((r) => ({ ...r, name: '*.example.com' })),
+    );
+    trie.add(
+      '*.sub.example.com',
+      'A',
+      records.map((r) => ({ ...r, name: '*.sub.example.com' })),
+    );
 
     const serialized = trie.toString();
     const deserialized = AnswerTrie.fromString(serialized);

--- a/src/common/store/trieStore.ts
+++ b/src/common/store/trieStore.ts
@@ -2,6 +2,7 @@ import { Store } from './Store';
 import { Answer, RecordType } from 'dns-packet';
 import { EventEmitter } from 'events';
 import { DNSRequest, DNSResponse, NextFunction, Handler } from '../../server';
+import { resolveWildcards } from '../core/domainToRegexp';
 
 interface DeserializedTrieData {
   trie: DeserializedTrie;
@@ -74,7 +75,7 @@ export class AnswerTrie {
         return response.map((record) => {
           return {
             ...record,
-            name: labels.toReversed().join('.') + '.' + record.name.replace(/\*/g, ''),
+            name: resolveWildcards(labels.toReversed().join('.'), record.name),
           };
         });
       }
@@ -82,7 +83,7 @@ export class AnswerTrie {
       return response.map((record) => {
         return {
           ...record,
-          name: labels.toReversed().join('.') + '.' + record.name.replace(/\*\./g, ''),
+          name: resolveWildcards(labels.toReversed().join('.'), record.name),
         };
       });
     }

--- a/src/common/store/trieStore.ts
+++ b/src/common/store/trieStore.ts
@@ -74,7 +74,7 @@ export class AnswerTrie {
         return response.map((record) => {
           return {
             ...record,
-            name: labels.toReversed().join('.') + '.' + record.name.replace('*', ''),
+            name: labels.toReversed().join('.') + '.' + record.name.replace(/\*/g, ''),
           };
         });
       }
@@ -82,7 +82,7 @@ export class AnswerTrie {
       return response.map((record) => {
         return {
           ...record,
-          name: labels.toReversed().join('.') + '.' + record.name.replace('*.', ''),
+          name: labels.toReversed().join('.') + '.' + record.name.replace(/\*\./g, ''),
         };
       });
     }


### PR DESCRIPTION
Fixes [https://github.com/jafayer/DinoDNS/security/code-scanning/2](https://github.com/jafayer/DinoDNS/security/code-scanning/2)

To fix the problem, we need to ensure that all occurrences of the wildcard character `*` in `record.name` are replaced. This can be achieved by using a regular expression with the global flag (`g`). This ensures that every instance of the wildcard character is replaced, not just the first one.

- Modify the `replace` method call on `record.name` to use a regular expression with the global flag.
- Specifically, change the `replace('*', '')` to `replace(/\*/g, '')` and `replace('*.', '')` to `replace(/\*\./g, '')`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
