### PR TITLE
Add SupportedAnswer type to resolve opt problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ server.start(() => {
 
 ### Answer types
 
-* OPT answers are currently unsupported
+- OPT answers are currently unsupported
 
 # Roadmap
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ server.start(() => {
 });
 ```
 
+## Unsupported features
+
+### Answer types
+
+* OPT answers are currently unsupported
+
 # Roadmap
 
 - [ ] Full documentation site up

--- a/src/common/logger/consoleLogger.ts
+++ b/src/common/logger/consoleLogger.ts
@@ -10,9 +10,9 @@ export class ConsoleLogger implements Logger {
 
   register(res: DNSResponse): void {
     res.once('done', () => {
-      if (res.packet.answers!.length > 0) {
+      if (res.packet.answers.length > 0) {
         console.log(
-          `[ANSWER] ${res.packet.answers![0].name} ${res.packet.answers![0].type} ${JSON.stringify((res.packet.answers![0] as dnsPacket.StringAnswer).data)} (took ${Date.now() - res.connection.ts}ms)`,
+          `[ANSWER] ${res.packet.answers[0].name} ${res.packet.answers[0].type} ${JSON.stringify(res.packet.answers[0].data)} (took ${Date.now() - res.connection.ts}ms)`,
         );
       }
     });

--- a/src/common/logger/consoleLogger.ts
+++ b/src/common/logger/consoleLogger.ts
@@ -1,6 +1,5 @@
 import { Logger, LogLevel } from './logger';
 import { DNSRequest, DNSResponse, NextFunction } from '../../server';
-import dnsPacket from 'dns-packet';
 
 export class ConsoleLogger implements Logger {
   constructor(

--- a/src/common/store/trieStore.spec.ts
+++ b/src/common/store/trieStore.spec.ts
@@ -1,5 +1,4 @@
 import { AnswerTrie } from './trieStore';
-import { Answer, StringAnswer } from 'dns-packet';
 import { SupportedAnswer } from '../../types/dnsLibTypes';
 
 const records: SupportedAnswer[] = [
@@ -179,8 +178,10 @@ describe('AnswerTrie', () => {
     expect(trie.get('another.example.com', 'A')).toEqual(records.map((r) => ({ ...r, name: 'another.example.com' })));
   });
 
-  it('should resolve the leftmost/least specific wildcard first if there are collissions', () => {
-    const leastSpecificWildcard = records.map((r) => ({ ...r, name: '*.example.com', data: '127.0.0.1' }) as SupportedAnswer);
+  it('should resolve the leftmost/least specific wildcard first if there are collisions', () => {
+    const leastSpecificWildcard = records.map(
+      (r) => ({ ...r, name: '*.example.com', data: '127.0.0.1' }) as SupportedAnswer,
+    );
     const moreSpecificWildcard = records.map(
       (r) => ({ ...r, name: '*.sub.example.com', data: '.127.0.0.2' }) as SupportedAnswer,
     );

--- a/src/common/store/trieStore.spec.ts
+++ b/src/common/store/trieStore.spec.ts
@@ -1,7 +1,8 @@
 import { AnswerTrie } from './trieStore';
 import { Answer, StringAnswer } from 'dns-packet';
+import { SupportedAnswer } from '../../types/dnsLibTypes';
 
-const records: Answer[] = [
+const records: SupportedAnswer[] = [
   {
     name: 'example.com',
     type: 'A',
@@ -31,7 +32,7 @@ describe('AnswerTrie', () => {
   });
 
   it('should be able to get data of a specific type', () => {
-    const mx: Answer[] = [
+    const mx: SupportedAnswer[] = [
       {
         name: 'example.com',
         type: 'MX',
@@ -162,7 +163,7 @@ describe('AnswerTrie', () => {
   });
 
   it('Should resolve an exact match before a wildcard match', () => {
-    const specificRecords: Answer[] = [
+    const specificRecords: SupportedAnswer[] = [
       { name: 'test.example.com', type: 'A', class: 'IN', ttl: 300, data: '127.0.0.3' },
     ];
     trie.add(
@@ -179,9 +180,9 @@ describe('AnswerTrie', () => {
   });
 
   it('should resolve the leftmost/least specific wildcard first if there are collissions', () => {
-    const leastSpecificWildcard = records.map((r) => ({ ...r, name: '*.example.com', data: '127.0.0.1' }) as Answer);
+    const leastSpecificWildcard = records.map((r) => ({ ...r, name: '*.example.com', data: '127.0.0.1' }) as SupportedAnswer);
     const moreSpecificWildcard = records.map(
-      (r) => ({ ...r, name: '*.sub.example.com', data: '.127.0.0.2' }) as Answer,
+      (r) => ({ ...r, name: '*.sub.example.com', data: '.127.0.0.2' }) as SupportedAnswer,
     );
 
     trie.add('*.example.com', 'A', leastSpecificWildcard);

--- a/src/common/store/trieStore.spec.ts
+++ b/src/common/store/trieStore.spec.ts
@@ -162,8 +162,14 @@ describe('AnswerTrie', () => {
   });
 
   it('Should resolve an exact match before a wildcard match', () => {
-    const specificRecords: Answer[] = [{name: 'test.example.com', type: 'A', class: 'IN', ttl: 300, data: '127.0.0.3'}];
-    trie.add('*.example.com', 'A', records.map((r) => ({ ...r, name: '*.example.com' })));
+    const specificRecords: Answer[] = [
+      { name: 'test.example.com', type: 'A', class: 'IN', ttl: 300, data: '127.0.0.3' },
+    ];
+    trie.add(
+      '*.example.com',
+      'A',
+      records.map((r) => ({ ...r, name: '*.example.com' })),
+    );
     trie.add('test.example.com', 'A', specificRecords);
 
     const result = trie.get('test.example.com', 'A');
@@ -173,8 +179,10 @@ describe('AnswerTrie', () => {
   });
 
   it('should resolve the leftmost/least specific wildcard first if there are collissions', () => {
-    const leastSpecificWildcard = records.map((r) => ({ ...r, name: '*.example.com', data: '127.0.0.1' } as Answer));
-    const moreSpecificWildcard = records.map((r) => ({ ...r, name: '*.sub.example.com', data: '.127.0.0.2' } as Answer));
+    const leastSpecificWildcard = records.map((r) => ({ ...r, name: '*.example.com', data: '127.0.0.1' }) as Answer);
+    const moreSpecificWildcard = records.map(
+      (r) => ({ ...r, name: '*.sub.example.com', data: '.127.0.0.2' }) as Answer,
+    );
 
     trie.add('*.example.com', 'A', leastSpecificWildcard);
     trie.add('*.sub.example.com', 'A', moreSpecificWildcard);

--- a/src/common/store/trieStore.ts
+++ b/src/common/store/trieStore.ts
@@ -118,7 +118,6 @@ export class AnswerTrie {
   }
 
   get(domain: string, rType?: RecordType): Answer[] | null {
-
     // first try to get the exact match
     const exact = this._getExact(this.domainToLabels(domain), rType);
     if (exact) {

--- a/src/common/store/trieStore.ts
+++ b/src/common/store/trieStore.ts
@@ -1,12 +1,13 @@
 import { Store } from './Store';
-import { Answer, RecordType } from 'dns-packet';
+import { RecordType } from 'dns-packet';
 import { EventEmitter } from 'events';
 import { DNSRequest, DNSResponse, NextFunction, Handler } from '../../server';
 import { resolveWildcards } from '../core/domainToRegexp';
+import { SupportedAnswer } from '../../types/dnsLibTypes';
 
 interface DeserializedTrieData {
   trie: DeserializedTrie;
-  data: [string, Answer[]][];
+  data: [string, SupportedAnswer[]][];
 }
 
 interface DeserializedTrie {
@@ -27,9 +28,9 @@ export class AnswerTrie {
    * It does not narrow the type of the record based on the specific record type. You should not be able, for example,
    * to add a record of type 'A' with an answer that is an MxAnswer.
    */
-  private data: Map<RecordType, Answer[]> = new Map();
+  private data: Map<RecordType, SupportedAnswer[]> = new Map();
 
-  private _insert(labels: string[], rType: RecordType, data: Answer[]) {
+  private _insert(labels: string[], rType: RecordType, data: SupportedAnswer[]) {
     if (labels.length === 0) {
       this.data.set(rType, data);
       return;
@@ -53,11 +54,11 @@ export class AnswerTrie {
     next._insert(rest, rType, data);
   }
 
-  add(domain: string, rType: RecordType, data: Answer[]) {
+  add(domain: string, rType: RecordType, data: SupportedAnswer[]) {
     this._insert(this.domainToLabels(domain), rType, data);
   }
 
-  private _getExact(labels: string[], rType?: RecordType): Answer[] | null {
+  private _getExact(labels: string[], rType?: RecordType): SupportedAnswer[] | null {
     if (labels.length === 0) {
       if (rType) {
         return this.data.get(rType) || null;
@@ -76,7 +77,7 @@ export class AnswerTrie {
     return next._getExact(rest, rType);
   }
 
-  private _get(labels: string[], rType?: RecordType): Answer[] | null {
+  private _get(labels: string[], rType?: RecordType): SupportedAnswer[] | null {
     if (labels.length === 0) {
       if (rType) {
         return this.data.get(rType) || null;
@@ -117,7 +118,7 @@ export class AnswerTrie {
     return next._get(rest, rType);
   }
 
-  get(domain: string, rType?: RecordType): Answer[] | null {
+  get(domain: string, rType?: RecordType): SupportedAnswer[] | null {
     // first try to get the exact match
     const exact = this._getExact(this.domainToLabels(domain), rType);
     if (exact) {
@@ -151,7 +152,7 @@ export class AnswerTrie {
     return this._has(this.domainToLabels(domain));
   }
 
-  private _delete(labels: string[], rType?: RecordType, rData?: Answer) {
+  private _delete(labels: string[], rType?: RecordType, rData?: SupportedAnswer) {
     if (labels.length === 0) {
       if (rType) {
         if (!rData) {
@@ -190,11 +191,11 @@ export class AnswerTrie {
     next._delete(rest, rType, rData);
   }
 
-  delete(domain: string, rType?: RecordType, rData?: Answer) {
+  delete(domain: string, rType?: RecordType, rData?: SupportedAnswer) {
     this._delete(this.domainToLabels(domain), rType, rData);
   }
 
-  append(domain: string, rType: RecordType, data: Answer) {
+  append(domain: string, rType: RecordType, data: SupportedAnswer) {
     const labels = this.domainToLabels(domain);
     const [label, ...rest] = labels;
     let next = this.trie.get(label);
@@ -286,19 +287,19 @@ export class AnswerTrie {
 export class TrieStore extends EventEmitter implements Store {
   trie: AnswerTrie = new AnswerTrie();
 
-  async get(zone: string, rType?: RecordType): Promise<Answer | Answer[] | null> {
+  async get(zone: string, rType?: RecordType): Promise<SupportedAnswer | SupportedAnswer[] | null> {
     return this.trie.get(zone, rType);
   }
 
-  async set(zone: string, rType: RecordType, data: Answer | Answer[]): Promise<void> {
+  async set(zone: string, rType: RecordType, data: SupportedAnswer | SupportedAnswer[]): Promise<void> {
     this.trie.add(zone, rType, Array.isArray(data) ? data : [data]);
   }
 
-  async append(zone: string, rType: RecordType, data: Answer): Promise<void> {
+  async append(zone: string, rType: RecordType, data: SupportedAnswer): Promise<void> {
     this.trie.append(zone, rType, data);
   }
 
-  async delete(zone: string, rType?: RecordType, rData?: Answer): Promise<void> {
+  async delete(zone: string, rType?: RecordType, rData?: SupportedAnswer): Promise<void> {
     this.trie.delete(zone, rType, rData);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ export * as logging from './common/logger';
 export * as server from './server';
 export * as store from './common/store';
 
+export { SupportedAnswer } from './types/dnsLibTypes';
+
 export {
   DNSOverTCP,
   DNSOverUDP,

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ s.use(store.handler);
 
 s.handle('example.net', (req, res) => {
   res.packet.answers = [
-    ...res.packet.answers!,
+    ...res.packet.answers,
     {
       type: 'SOA',
       name: 'example.net',
@@ -126,7 +126,7 @@ s.handle('example.net', (req, res) => {
     },
   ];
   res.packet.answers = [
-    ...res.packet.answers!,
+    ...res.packet.answers,
     {
       type: 'A',
       name: 'example.net',

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -3,6 +3,7 @@ import { Connection } from '../common/network';
 import { CanAnswer } from '../common/dns';
 import { CombineFlags, RCode } from '../common/core/utils';
 import { EventEmitter } from 'events';
+import { SupportedAnswer } from '../types/dnsLibTypes';
 
 export interface NextFunction {
   (err?: Error): void;
@@ -85,22 +86,22 @@ class PacketWrapper {
     this.raw.questions = questions;
   }
 
-  get answers(): ReadonlyArray<dnsPacket.Answer> {
-    return this.raw.answers || [];
+  get answers(): ReadonlyArray<SupportedAnswer> {
+    return (this.raw.answers as ReadonlyArray<SupportedAnswer>) || [];
   }
 
-  set answers(answers: dnsPacket.Answer[]) {
+  set answers(answers: SupportedAnswer[]) {
     if (this.frozen) {
       throw new ModifiedAfterSentError();
     }
     this.raw.answers = answers || [];
   }
 
-  get additionals(): ReadonlyArray<dnsPacket.Answer> {
-    return this.raw.additionals || [];
+  get additionals(): ReadonlyArray<SupportedAnswer> {
+    return (this.raw.additionals || []) as ReadonlyArray<SupportedAnswer>;
   }
 
-  set additionals(additionals: dnsPacket.Answer[]) {
+  set additionals(additionals: SupportedAnswer[]) {
     if (this.frozen) {
       throw new ModifiedAfterSentError();
     }
@@ -152,7 +153,7 @@ export class DNSResponse extends EventEmitter {
     return this.fin;
   }
 
-  answer(answer: dnsPacket.Answer | dnsPacket.Answer[]): void {
+  answer(answer: SupportedAnswer | SupportedAnswer[]): void {
     if (this.fin) {
       throw new DuplicateAnswerForRequest();
     }

--- a/src/types/dnsLibTypes.ts
+++ b/src/types/dnsLibTypes.ts
@@ -16,6 +16,8 @@ import type {
   DnskeyData,
   StringRecordType,
   OtherRecordType,
+  Answer,
+  OptAnswer,
 } from 'dns-packet';
 
 /**
@@ -44,3 +46,6 @@ export type ZoneData = {
   TLSA: TlsaData;
   TXT: TxtData;
 };
+
+export type SupportedAnswer = Exclude<Answer, OptAnswer>;
+export type SupportedRecordType = keyof ZoneData;

--- a/tests/server.spec.ts
+++ b/tests/server.spec.ts
@@ -36,7 +36,7 @@ describe('server', () => {
 
     server.handle('example.com', (req, res) => {
       res.packet.answers = [
-        ...res.packet.answers!,
+        ...res.packet.answers,
         {
           type: 'SOA',
           name: 'example.net',
@@ -52,7 +52,7 @@ describe('server', () => {
         },
       ];
       res.packet.answers = [
-        ...res.packet.answers!,
+        ...res.packet.answers,
         {
           type: 'A',
           name: 'example.net',


### PR DESCRIPTION
As it currently stands, the `OptAnswer` Answer type is a problem for this code because it is the only type that lacks a `data` key in its object definition.

This caused intractable type issues when attempting to do things like

```ts
res.packet.answers.map(({data}) => {
    console.log(data);
  });
```

This pull request notably introduces an exclusion of support for the OPT query type for now.


This PR also replaces non-null assertion operators and updates a few type definitions.

### Type Safety Improvements:
* [`src/common/logger/consoleLogger.ts`](diffhunk://#diff-d8dc6ed9587551a660ae98842eea80474eb4d1d6e826e6e0f6db50f2827cf672L13-R15): Removed non-null assertion operators from `res.packet.answers` and simplified the logging statement.
* [`src/server/types.ts`](diffhunk://#diff-9a3a0a5fdd0766b53ba8436a42cd88d004c2dadf2853adbe4ca061f4b2215a40L88-R104): Updated the `PacketWrapper` class to use `SupportedAnswer` instead of `dnsPacket.Answer` for better type safety.
* [`src/server/types.ts`](diffhunk://#diff-9a3a0a5fdd0766b53ba8436a42cd88d004c2dadf2853adbe4ca061f4b2215a40L155-R156): Updated the `DNSResponse` class to use `SupportedAnswer` instead of `dnsPacket.Answer` for the `answer` method.
* `src/index.ts` and `tests/server.spec.ts`: Removed non-null assertion operators from `res.packet.answers` in multiple locations. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L113-R113) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L129-R129) [[3]](diffhunk://#diff-0a5904d46dc9c0a7fc2c463bd354aea07d29af1a7c2468caf2a5d8f4831ca54fL39-R39) [[4]](diffhunk://#diff-0a5904d46dc9c0a7fc2c463bd354aea07d29af1a7c2468caf2a5d8f4831ca54fL55-R55)

### Type Definition Updates:
* [`src/types/dnsLibTypes.ts`](diffhunk://#diff-71f4571c2feb90941141cab79fc535dd75ce3b6cd3329ee6601635f34e823750R19-R20): Added new type definitions `SupportedAnswer` and `SupportedRecordType` to exclude unsupported answers and define supported record types. [[1]](diffhunk://#diff-71f4571c2feb90941141cab79fc535dd75ce3b6cd3329ee6601635f34e823750R19-R20) [[2]](diffhunk://#diff-71f4571c2feb90941141cab79fc535dd75ce3b6cd3329ee6601635f34e823750R49-R51)

### Code Readability Improvements:
* [`src/common/store/trieStore.spec.ts`](diffhunk://#diff-e3c868b9bf41b049409824acbc9a7f6e7c6abf75abdd5cf7ad8a30ba94ceb84cL165-R172): Reformatted code for better readability in test cases involving wildcard matches. [[1]](diffhunk://#diff-e3c868b9bf41b049409824acbc9a7f6e7c6abf75abdd5cf7ad8a30ba94ceb84cL165-R172) [[2]](diffhunk://#diff-e3c868b9bf41b049409824acbc9a7f6e7c6abf75abdd5cf7ad8a30ba94ceb84cL176-R185)
* [`src/common/store/trieStore.ts`](diffhunk://#diff-1abda7763158bc3e2d589f6a57e937dc27636ceeaf454c30b3c2e2cc5b3280bdL121): Removed an unnecessary blank line in the `AnswerTrie` class.