### PR TITLE
Remove await in network handlers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN npm run build
 
 EXPOSE 1053
 
-CMD [ "node", "dist/bundle.js" ]
+CMD [ "node", "dist/index.js" ]

--- a/src/common/network/tcp.ts
+++ b/src/common/network/tcp.ts
@@ -40,8 +40,20 @@ export class DNSOverTCP implements Network<dnsPacket.Packet> {
           throw new Error('No handler defined for DNSOverTCP');
         }
         const packet = dnsPacket.streamDecode(data);
-        const resp = await this.handler(packet, this.toConnection(socket));
-        socket.write(new Uint8Array(this.serializer.encode(resp.packet.raw)));
+        this.handler(packet, this.toConnection(socket))
+        .then((resp) => {
+          socket.write(new Uint8Array(this.serializer.encode(resp.packet.raw)));
+          socket.end();
+        })
+        .catch((err) => {
+          console.error(err);
+          socket.end();
+        });
+      });
+
+      socket.on('error', (err) => {
+        console.error(err);
+        socket.end();
       });
 
       socket.on('end', () => {

--- a/src/common/network/tcp.ts
+++ b/src/common/network/tcp.ts
@@ -41,14 +41,14 @@ export class DNSOverTCP implements Network<dnsPacket.Packet> {
         }
         const packet = dnsPacket.streamDecode(data);
         this.handler(packet, this.toConnection(socket))
-        .then((resp) => {
-          socket.write(new Uint8Array(this.serializer.encode(resp.packet.raw)));
-          socket.end();
-        })
-        .catch((err) => {
-          console.error(err);
-          socket.end();
-        });
+          .then((resp) => {
+            socket.write(new Uint8Array(this.serializer.encode(resp.packet.raw)));
+            socket.end();
+          })
+          .catch((err) => {
+            console.error(err);
+            socket.end();
+          });
       });
 
       socket.on('error', (err) => {

--- a/src/common/network/udp.ts
+++ b/src/common/network/udp.ts
@@ -47,8 +47,17 @@ export class DNSOverUDP implements Network<dnsPacket.Packet> {
       }
 
       const packet = this.serializer.decode(msg);
-      const resp = await this.handler(packet, this.toConnection(rinfo));
-      this.server.send(new Uint8Array(this.serializer.encode(resp.packet.raw)), rinfo.port, rinfo.address);
+      this.handler(packet, this.toConnection(rinfo))
+      .then((resp) => {
+        this.server.send(new Uint8Array(this.serializer.encode(resp.packet.raw)), rinfo.port, rinfo.address);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+    });
+
+    this.server.on('error', (err) => {
+      console.error(err);
     });
   }
 

--- a/src/common/network/udp.ts
+++ b/src/common/network/udp.ts
@@ -48,12 +48,12 @@ export class DNSOverUDP implements Network<dnsPacket.Packet> {
 
       const packet = this.serializer.decode(msg);
       this.handler(packet, this.toConnection(rinfo))
-      .then((resp) => {
-        this.server.send(new Uint8Array(this.serializer.encode(resp.packet.raw)), rinfo.port, rinfo.address);
-      })
-      .catch((err) => {
-        console.error(err);
-      });
+        .then((resp) => {
+          this.server.send(new Uint8Array(this.serializer.encode(resp.packet.raw)), rinfo.port, rinfo.address);
+        })
+        .catch((err) => {
+          console.error(err);
+        });
     });
 
     this.server.on('error', (err) => {


### PR DESCRIPTION
There doesn't appear to be much of a meaningful performance difference between the `await` and `.then` implementations in this situation, but it does make it a little bit easier to chain error handling onto the handlers just to make this a little bit more hardened to crashes.

A sidenote: did some load testing and with this current implementation, I was able to benchmark locally with a wildcard query generator using Locust. QPS was ~2600 peak, but with only 40% utilization on 1CPU/1GB before my computer stopped being able to support Locust's efforts to generate queries.

Will clearly require some more robust load testing infrastructure.

### Dockerfile Update:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L19-R19): Changed the `CMD` directive to use `dist/index.js` instead of `dist/bundle.js` to reflect the correct entry point for the application.

### Error Handling Improvements:

* [`src/common/network/tcp.ts`](diffhunk://#diff-9632900f3b3a46d448f9bcdca39e8d907dc8267f5047c81978b84382c78b4607L43-R56): Enhanced error handling in the `DNSOverTCP` class by adding `.catch` for promise rejections and a new `error` event listener on the socket to log errors and ensure the socket is properly closed.
* [`src/common/network/udp.ts`](diffhunk://#diff-1a1c89d34ae3a05a6e88d1aa732d400d1aa84f3a7471e465486bc536c4db0ee8L50-R60): Improved error handling in the `DNSOverUDP` class by adding `.catch` for promise rejections and a new `error` event listener on the server to log errors.