### PR TITLE
Add cache plugin

### DIFF
--- a/src/plugins/cache/Cache.ts
+++ b/src/plugins/cache/Cache.ts
@@ -1,60 +1,51 @@
-import { Handler } from "../../types/server";
-import { ZoneData, SupportedRecordType } from "../../types/dns";
-import { Awaitable } from "../../common/core/utils";
+import { Handler } from '../../types/server';
+import { ZoneData, SupportedRecordType } from '../../types/dns';
+import { Awaitable } from '../../common/core/utils';
 
 export abstract class Cache {
-    
-    /**
-     * Get information about a zone in the cache.
-     * 
-     * @param zone the zone to get
-     * @param rType the record type to get. If not provided, all records in the zone should be retrieved.
-     */
-    abstract get<T extends SupportedRecordType>(
-        zone: string,
-        rType: T,
-    ): Awaitable<ZoneData[T][] | ZoneData[keyof ZoneData][] | null>;
+  /**
+   * Get information about a zone in the cache.
+   *
+   * @param zone the zone to get
+   * @param rType the record type to get. If not provided, all records in the zone should be retrieved.
+   */
+  abstract get<T extends SupportedRecordType>(
+    zone: string,
+    rType: T,
+  ): Awaitable<ZoneData[T][] | ZoneData[keyof ZoneData][] | null>;
 
-    /**
-     * Set or update information about a zone in the cache.
-     * 
-     * @param zone the zone to set
-     * @param rType the record type to set
-     * @param data the data to set
-     */
-    abstract set<T extends SupportedRecordType>(
-        zone: string,
-        rType: T,
-        data: ZoneData[T] | ZoneData[T][],
-    ): Awaitable<void>;
+  /**
+   * Set or update information about a zone in the cache.
+   *
+   * @param zone the zone to set
+   * @param rType the record type to set
+   * @param data the data to set
+   */
+  abstract set<T extends SupportedRecordType>(
+    zone: string,
+    rType: T,
+    data: ZoneData[T] | ZoneData[T][],
+  ): Awaitable<void>;
 
-    /**
-     * Append information about a zone in the cache.
-     * 
-     * @param zone the zone to append
-     * @param rType the record type to append
-     * @param data the data to append
-     */
-    abstract append<T extends SupportedRecordType>(
-        zone: string,
-        rType: T,
-        data: ZoneData[T],
-    ): Awaitable<void>;
+  /**
+   * Append information about a zone in the cache.
+   *
+   * @param zone the zone to append
+   * @param rType the record type to append
+   * @param data the data to append
+   */
+  abstract append<T extends SupportedRecordType>(zone: string, rType: T, data: ZoneData[T]): Awaitable<void>;
 
-    /**
-     * Delete information about a zone in the cache.
-     * 
-     * @param zone the zone to delete
-     * @param rType the record type to delete. If not provided, all records in the zone should be deleted.
-     * @param data the data to delete. If not provided, all records of the given type should be deleted.
-     */
-    abstract delete<T extends SupportedRecordType>(
-        zone: string,
-        rType: T,
-        data?: ZoneData[T],
-    ): Awaitable<void>;
+  /**
+   * Delete information about a zone in the cache.
+   *
+   * @param zone the zone to delete
+   * @param rType the record type to delete. If not provided, all records in the zone should be deleted.
+   * @param data the data to delete. If not provided, all records of the given type should be deleted.
+   */
+  abstract delete<T extends SupportedRecordType>(zone: string, rType: T, data?: ZoneData[T]): Awaitable<void>;
 
-    abstract clear(): Awaitable<void>;
+  abstract clear(): Awaitable<void>;
 
-    abstract handler: Handler;
+  abstract handler: Handler;
 }

--- a/src/plugins/cache/Cache.ts
+++ b/src/plugins/cache/Cache.ts
@@ -1,0 +1,60 @@
+import { Handler } from "../../types/server";
+import { ZoneData, SupportedRecordType } from "../../types/dns";
+import { Awaitable } from "../../common/core/utils";
+
+export abstract class Cache {
+    
+    /**
+     * Get information about a zone in the cache.
+     * 
+     * @param zone the zone to get
+     * @param rType the record type to get. If not provided, all records in the zone should be retrieved.
+     */
+    abstract get<T extends SupportedRecordType>(
+        zone: string,
+        rType: T,
+    ): Awaitable<ZoneData[T][] | ZoneData[keyof ZoneData][] | null>;
+
+    /**
+     * Set or update information about a zone in the cache.
+     * 
+     * @param zone the zone to set
+     * @param rType the record type to set
+     * @param data the data to set
+     */
+    abstract set<T extends SupportedRecordType>(
+        zone: string,
+        rType: T,
+        data: ZoneData[T] | ZoneData[T][],
+    ): Awaitable<void>;
+
+    /**
+     * Append information about a zone in the cache.
+     * 
+     * @param zone the zone to append
+     * @param rType the record type to append
+     * @param data the data to append
+     */
+    abstract append<T extends SupportedRecordType>(
+        zone: string,
+        rType: T,
+        data: ZoneData[T],
+    ): Awaitable<void>;
+
+    /**
+     * Delete information about a zone in the cache.
+     * 
+     * @param zone the zone to delete
+     * @param rType the record type to delete. If not provided, all records in the zone should be deleted.
+     * @param data the data to delete. If not provided, all records of the given type should be deleted.
+     */
+    abstract delete<T extends SupportedRecordType>(
+        zone: string,
+        rType: T,
+        data?: ZoneData[T],
+    ): Awaitable<void>;
+
+    abstract clear(): Awaitable<void>;
+
+    abstract handler: Handler;
+}

--- a/src/plugins/cache/DefaultCache/defaultCache.spec.ts
+++ b/src/plugins/cache/DefaultCache/defaultCache.spec.ts
@@ -1,321 +1,319 @@
-import {DefaultCache} from "./index";
-import { ZoneData, SupportedAnswer, SupportedRecordType } from "../../../types/dns";
+import { DefaultCache } from './index';
+import { ZoneData, SupportedAnswer, SupportedRecordType } from '../../../types/dns';
 
 describe('DefaultCache', () => {
-    let cache: DefaultCache;
-    
-    beforeEach(() => {
-        cache = new DefaultCache();
-    });
-    
-    describe('set', () => {
-        it('should set a single record', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'] = '127.0.0.1' ;
-    
-            cache.set(zone, rType, data);
-    
-            const result = cache.get(zone, rType);
-            expect(result).toEqual([data]);
-        });
+  let cache: DefaultCache;
 
-        it('should set multiple records', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
-    
-            cache.set(zone, rType, data);
-    
-            const result = cache.get(zone, rType);
-            expect(result).toEqual(data);
-        });
+  beforeEach(() => {
+    cache = new DefaultCache();
+  });
 
-        it('should evict a random member when the cache is full', () => {
-            cache = new DefaultCache({ maxEntries: 3 });
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'][] = Array.from({ length: 10 }, (_, i) => `127.0.0.${i + 1}`);
-            const domains = Array.from({ length: 10 }, (_, i) => `example${i}.com`);
+  describe('set', () => {
+    it('should set a single record', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'] = '127.0.0.1';
 
-            const pairs = domains.map((domain, i) => [domain, data[i]] as [string, ZoneData['A']]);
+      cache.set(zone, rType, data);
 
-            pairs.forEach(([domain, record]) => cache.set(domain, rType, record));
-            const results = pairs.map(([domain, _]) => cache.get(domain, rType));
-            const filtered = results.filter(Boolean);
-            expect(filtered.length).toBe(3);
-            expect(cache.size).toBe(3);
-        });
-
-        it('should not set any records when cache size is 0', () => {
-            cache = new DefaultCache({ maxEntries: 0 });
-
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'] = '127.0.0.1';
-
-            cache.set(zone, rType, data);
-
-            const result = cache.get(zone, rType);
-
-            expect(result).toBe(null);
-
-            expect(cache.size).toBe(0);
-        });
+      const result = cache.get(zone, rType);
+      expect(result).toEqual([data]);
     });
 
-    describe('append', () => {
-        it('should append a single record', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'] = '127.0.0.1';
-    
-            cache.append(zone, rType, data);
-    
-            const result = cache.get(zone, rType);
-            expect(result).toEqual([data]);
-        });
+    it('should set multiple records', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
 
-        it('should append multiple records', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data1: ZoneData['A'] = '127.0.0.1';
-            const data2: ZoneData['A'] = '127.0.0.2';
-    
-            cache.append(zone, rType, data1);
-            cache.append(zone, rType, data2);
-    
-            const result = cache.get(zone, rType);
-            expect(result).toEqual([data1, data2]);
-        });
+      cache.set(zone, rType, data);
 
-        it('should append to an existing record', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data1: ZoneData['A'] = '127.0.0.1';
-            const data2: ZoneData['A'] = '127.0.0.2';
-    
-            cache.set(zone, rType, data1);
-            cache.append(zone, rType, data2);
-    
-            const result = cache.get(zone, rType);
-            expect(result).toEqual([data1, data2]);
-        });
-
-        it('should append when the cache is full', () => {
-            const domains = Array.from({ length: 4 }, (_, i) => `example${i}.com`);
-            const data: ZoneData['A'][] = Array.from({ length: 4 }, (_, i) => `127.0.0.${i + 1}`);
-            const rType: SupportedRecordType = 'A';
-            const pairs = domains.map((domain, i) => [domain, data[i]] as [string, ZoneData['A']]);
-
-            pairs.forEach(([domain, record]) => {
-                cache.append(domain, rType, record);
-                cache.append(domain, rType, record);
-            });
-
-            const results = pairs.map(([domain, _]) => cache.get(domain, rType));
-            const filtered = results.filter(Boolean);
-            expect(filtered.length).toBe(4);
-
-            expect(filtered[0]!.length).toBe(2);
-            expect(cache.size).toBe(4);
-        });
-
-        it('should not append any records when cache size is 0', () => {
-            cache = new DefaultCache({ maxEntries: 0 });
-
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'] = '127.0.0.1';
-
-            cache.append(zone, rType, data);
-
-            const result = cache.get(zone, rType);
-
-            console.log(cache.cache);
-
-            expect(result).toBe(null);
-
-            expect(cache.size).toBe(0);
-
-        });
+      const result = cache.get(zone, rType);
+      expect(result).toEqual(data);
     });
 
-    describe('get', () => {
-        it('Should get a single record', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'] = '127.0.0.1';
+    it('should evict a random member when the cache is full', () => {
+      cache = new DefaultCache({ maxEntries: 3 });
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'][] = Array.from({ length: 10 }, (_, i) => `127.0.0.${i + 1}`);
+      const domains = Array.from({ length: 10 }, (_, i) => `example${i}.com`);
 
-            cache.set(zone, rType, data);
+      const pairs = domains.map((domain, i) => [domain, data[i]] as [string, ZoneData['A']]);
 
-            const result = cache.get(zone, rType);
-            expect(result).toEqual([data]);
-        });
-
-        it('Should get multiple records', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
-
-            cache.set(zone, rType, data);
-
-            const result = cache.get(zone, rType);
-            expect(result).toEqual(data);
-        });
-
-        it('should return null when the zone does not exist', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-
-            const result = cache.get(zone, rType);
-            expect(result).toBe(null);
-        });
-
-        it('should return null when the record type does not exist', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-
-            cache.set(zone, rType, '127.0.0.1');
-
-            expect(cache.get(zone, 'A')).toEqual(['127.0.0.1']);
-            expect(cache.get(zone, 'AAAA')).toBe(null);
-        });
+      pairs.forEach(([domain, record]) => cache.set(domain, rType, record));
+      const results = pairs.map(([domain, _]) => cache.get(domain, rType));
+      const filtered = results.filter(Boolean);
+      expect(filtered.length).toBe(3);
+      expect(cache.size).toBe(3);
     });
 
-    describe('delete', () => {
-        it('should delete a single record', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'] = '127.0.0.1';
+    it('should not set any records when cache size is 0', () => {
+      cache = new DefaultCache({ maxEntries: 0 });
 
-            cache.set(zone, rType, data);
-            expect(cache.get(zone, rType)).toEqual([data]);
-            cache.delete(zone, rType, data);
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'] = '127.0.0.1';
 
-            const result = cache.get(zone, rType);
-            expect(result).toBe(null);
-        });
+      cache.set(zone, rType, data);
 
-        it('should delete multiple records', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+      const result = cache.get(zone, rType);
 
-            cache.set(zone, rType, data);
-            expect(cache.get(zone, rType)).toEqual(data);
-            cache.delete(zone, rType);
-            expect(cache.get(zone, rType)).toBe(null);
-        });
+      expect(result).toBe(null);
 
-        it('should delete a specific record', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+      expect(cache.size).toBe(0);
+    });
+  });
 
-            cache.set(zone, rType, data);
-            expect(cache.get(zone, rType)).toEqual(data);
-            cache.delete(zone, rType, data[0]);
-            expect(cache.get(zone, rType)).toEqual([data[1]]);
-        });
+  describe('append', () => {
+    it('should append a single record', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'] = '127.0.0.1';
 
-        it('should handle deleting a record that does not exist', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'] = '127.0.0.1'; 
+      cache.append(zone, rType, data);
 
-            cache.set(zone, rType, data);
-            expect(cache.get(zone, rType)).toEqual([data]);
-            cache.delete(zone, rType, '127.0.0.2');
-
-            const result = cache.get(zone, rType);
-            expect(result).toEqual([data]);
-        });
-
-        it('should handle deleting a record from an empty zone', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'] = '127.0.0.1';
-
-            cache.set(zone, rType, data);
-            
-            // don't throw an error deleting an empty zone
-            expect(() => cache.delete('example2.com', rType, '127.0.0.2')).not.toThrow();
-            
-            expect(cache.get(zone, rType)).toEqual([data]);
-        });
-
+      const result = cache.get(zone, rType);
+      expect(result).toEqual([data]);
     });
 
-    describe('eviction', () => {
-        it('should evict a random member', () => {
-            cache = new DefaultCache({ maxEntries: 1 });
+    it('should append multiple records', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data1: ZoneData['A'] = '127.0.0.1';
+      const data2: ZoneData['A'] = '127.0.0.2';
 
-            const zones = ['example1.com', 'example2.com'];
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+      cache.append(zone, rType, data1);
+      cache.append(zone, rType, data2);
 
-            zones.forEach((zone, i) => cache.set(zone, rType, data[i]));
-
-            expect(cache.size).toBe(1);
-
-            const results = zones.map((zone) => cache.get(zone, rType));
-
-            expect(results.every(Boolean)).toBe(false);
-
-            cache.evictRandomMember();
-
-            expect(cache.size).toBe(0);
-        });
-
-        it('should evict until empty', () => {
-            cache = new DefaultCache({ maxEntries: 100 });
-
-            const zones = Array.from({ length: 100 }, (_, i) => `example${i}.com`);
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'][] = Array.from({ length: 100 }, (_, i) => `127.0.0.${i + 1}`);
-
-            zones.forEach((zone, i) => cache.set(zone, rType, data[i]));
-
-            expect(cache.size).toBe(100);
-
-            for (let i = 0; i < 100; i++) {
-                cache.evictRandomMember();
-
-                expect(cache.size).toBe(100 - i - 1);
-            }
-        });
-
-        it('should not error when evicting from an empty cache', () => {
-            cache = new DefaultCache({ maxEntries: 0 });
-
-            expect(() => cache.evictRandomMember()).not.toThrow();
-        });
-    }); 
-
-    describe('clear', () => {
-        it('should clear the cache', () => {
-            cache = new DefaultCache({ maxEntries: 100 });
-            const zones = Array.from({ length: 100 }, (_, i) => `example${i}.com`);
-            const rType: SupportedRecordType = 'A';
-            const data: ZoneData['A'][] = Array.from({ length: 100 }, (_, i) => `127.0.0.${i + 1}`);
-
-            zones.forEach((zone, i) => cache.set(zone, rType, data[i]));
-
-            expect(cache.size).toBe(100);
-
-            cache.clear();
-
-            expect(cache.size).toBe(0);
-        });
+      const result = cache.get(zone, rType);
+      expect(result).toEqual([data1, data2]);
     });
 
-    describe('getKey', () => {
-        it('should return the key for a zone and record type', () => {
-            const zone = 'example.com';
-            const rType: SupportedRecordType = 'A';
+    it('should append to an existing record', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data1: ZoneData['A'] = '127.0.0.1';
+      const data2: ZoneData['A'] = '127.0.0.2';
 
-            expect(DefaultCache.getKey(zone, rType)).toBe('example.com:A');
-        });
+      cache.set(zone, rType, data1);
+      cache.append(zone, rType, data2);
+
+      const result = cache.get(zone, rType);
+      expect(result).toEqual([data1, data2]);
     });
+
+    it('should append when the cache is full', () => {
+      const domains = Array.from({ length: 4 }, (_, i) => `example${i}.com`);
+      const data: ZoneData['A'][] = Array.from({ length: 4 }, (_, i) => `127.0.0.${i + 1}`);
+      const rType: SupportedRecordType = 'A';
+      const pairs = domains.map((domain, i) => [domain, data[i]] as [string, ZoneData['A']]);
+
+      pairs.forEach(([domain, record]) => {
+        cache.append(domain, rType, record);
+        cache.append(domain, rType, record);
+      });
+
+      const results = pairs.map(([domain, _]) => cache.get(domain, rType));
+      const filtered = results.filter(Boolean);
+      expect(filtered.length).toBe(4);
+
+      expect(filtered[0]!.length).toBe(2);
+      expect(cache.size).toBe(4);
+    });
+
+    it('should not append any records when cache size is 0', () => {
+      cache = new DefaultCache({ maxEntries: 0 });
+
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'] = '127.0.0.1';
+
+      cache.append(zone, rType, data);
+
+      const result = cache.get(zone, rType);
+
+      console.log(cache.cache);
+
+      expect(result).toBe(null);
+
+      expect(cache.size).toBe(0);
+    });
+  });
+
+  describe('get', () => {
+    it('Should get a single record', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'] = '127.0.0.1';
+
+      cache.set(zone, rType, data);
+
+      const result = cache.get(zone, rType);
+      expect(result).toEqual([data]);
+    });
+
+    it('Should get multiple records', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+
+      cache.set(zone, rType, data);
+
+      const result = cache.get(zone, rType);
+      expect(result).toEqual(data);
+    });
+
+    it('should return null when the zone does not exist', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+
+      const result = cache.get(zone, rType);
+      expect(result).toBe(null);
+    });
+
+    it('should return null when the record type does not exist', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+
+      cache.set(zone, rType, '127.0.0.1');
+
+      expect(cache.get(zone, 'A')).toEqual(['127.0.0.1']);
+      expect(cache.get(zone, 'AAAA')).toBe(null);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a single record', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'] = '127.0.0.1';
+
+      cache.set(zone, rType, data);
+      expect(cache.get(zone, rType)).toEqual([data]);
+      cache.delete(zone, rType, data);
+
+      const result = cache.get(zone, rType);
+      expect(result).toBe(null);
+    });
+
+    it('should delete multiple records', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+
+      cache.set(zone, rType, data);
+      expect(cache.get(zone, rType)).toEqual(data);
+      cache.delete(zone, rType);
+      expect(cache.get(zone, rType)).toBe(null);
+    });
+
+    it('should delete a specific record', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+
+      cache.set(zone, rType, data);
+      expect(cache.get(zone, rType)).toEqual(data);
+      cache.delete(zone, rType, data[0]);
+      expect(cache.get(zone, rType)).toEqual([data[1]]);
+    });
+
+    it('should handle deleting a record that does not exist', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'] = '127.0.0.1';
+
+      cache.set(zone, rType, data);
+      expect(cache.get(zone, rType)).toEqual([data]);
+      cache.delete(zone, rType, '127.0.0.2');
+
+      const result = cache.get(zone, rType);
+      expect(result).toEqual([data]);
+    });
+
+    it('should handle deleting a record from an empty zone', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'] = '127.0.0.1';
+
+      cache.set(zone, rType, data);
+
+      // don't throw an error deleting an empty zone
+      expect(() => cache.delete('example2.com', rType, '127.0.0.2')).not.toThrow();
+
+      expect(cache.get(zone, rType)).toEqual([data]);
+    });
+  });
+
+  describe('eviction', () => {
+    it('should evict a random member', () => {
+      cache = new DefaultCache({ maxEntries: 1 });
+
+      const zones = ['example1.com', 'example2.com'];
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+
+      zones.forEach((zone, i) => cache.set(zone, rType, data[i]));
+
+      expect(cache.size).toBe(1);
+
+      const results = zones.map((zone) => cache.get(zone, rType));
+
+      expect(results.every(Boolean)).toBe(false);
+
+      cache.evictRandomMember();
+
+      expect(cache.size).toBe(0);
+    });
+
+    it('should evict until empty', () => {
+      cache = new DefaultCache({ maxEntries: 100 });
+
+      const zones = Array.from({ length: 100 }, (_, i) => `example${i}.com`);
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'][] = Array.from({ length: 100 }, (_, i) => `127.0.0.${i + 1}`);
+
+      zones.forEach((zone, i) => cache.set(zone, rType, data[i]));
+
+      expect(cache.size).toBe(100);
+
+      for (let i = 0; i < 100; i++) {
+        cache.evictRandomMember();
+
+        expect(cache.size).toBe(100 - i - 1);
+      }
+    });
+
+    it('should not error when evicting from an empty cache', () => {
+      cache = new DefaultCache({ maxEntries: 0 });
+
+      expect(() => cache.evictRandomMember()).not.toThrow();
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear the cache', () => {
+      cache = new DefaultCache({ maxEntries: 100 });
+      const zones = Array.from({ length: 100 }, (_, i) => `example${i}.com`);
+      const rType: SupportedRecordType = 'A';
+      const data: ZoneData['A'][] = Array.from({ length: 100 }, (_, i) => `127.0.0.${i + 1}`);
+
+      zones.forEach((zone, i) => cache.set(zone, rType, data[i]));
+
+      expect(cache.size).toBe(100);
+
+      cache.clear();
+
+      expect(cache.size).toBe(0);
+    });
+  });
+
+  describe('getKey', () => {
+    it('should return the key for a zone and record type', () => {
+      const zone = 'example.com';
+      const rType: SupportedRecordType = 'A';
+
+      expect(DefaultCache.getKey(zone, rType)).toBe('example.com:A');
+    });
+  });
 });

--- a/src/plugins/cache/DefaultCache/defaultCache.spec.ts
+++ b/src/plugins/cache/DefaultCache/defaultCache.spec.ts
@@ -1,5 +1,5 @@
 import { DefaultCache } from './index';
-import { ZoneData, SupportedAnswer, SupportedRecordType } from '../../../types/dns';
+import { ZoneData, SupportedRecordType } from '../../../types/dns';
 
 describe('DefaultCache', () => {
   let cache: DefaultCache;
@@ -33,7 +33,6 @@ describe('DefaultCache', () => {
 
     it('should evict a random member when the cache is full', () => {
       cache = new DefaultCache({ maxEntries: 3 });
-      const zone = 'example.com';
       const rType: SupportedRecordType = 'A';
       const data: ZoneData['A'][] = Array.from({ length: 10 }, (_, i) => `127.0.0.${i + 1}`);
       const domains = Array.from({ length: 10 }, (_, i) => `example${i}.com`);
@@ -41,7 +40,7 @@ describe('DefaultCache', () => {
       const pairs = domains.map((domain, i) => [domain, data[i]] as [string, ZoneData['A']]);
 
       pairs.forEach(([domain, record]) => cache.set(domain, rType, record));
-      const results = pairs.map(([domain, _]) => cache.get(domain, rType));
+      const results = pairs.map(([domain]) => cache.get(domain, rType));
       const filtered = results.filter(Boolean);
       expect(filtered.length).toBe(3);
       expect(cache.size).toBe(3);
@@ -113,7 +112,7 @@ describe('DefaultCache', () => {
         cache.append(domain, rType, record);
       });
 
-      const results = pairs.map(([domain, _]) => cache.get(domain, rType));
+      const results = pairs.map(([domain]) => cache.get(domain, rType));
       const filtered = results.filter(Boolean);
       expect(filtered.length).toBe(4);
 

--- a/src/plugins/cache/DefaultCache/defaultCache.spec.ts
+++ b/src/plugins/cache/DefaultCache/defaultCache.spec.ts
@@ -32,6 +32,7 @@ describe('DefaultCache', () => {
         });
 
         it('should evict a random member when the cache is full', () => {
+            cache = new DefaultCache({ maxEntries: 3 });
             const zone = 'example.com';
             const rType: SupportedRecordType = 'A';
             const data: ZoneData['A'][] = Array.from({ length: 10 }, (_, i) => `127.0.0.${i + 1}`);
@@ -114,10 +115,10 @@ describe('DefaultCache', () => {
 
             const results = pairs.map(([domain, _]) => cache.get(domain, rType));
             const filtered = results.filter(Boolean);
-            expect(filtered.length).toBe(3);
+            expect(filtered.length).toBe(4);
 
             expect(filtered[0]!.length).toBe(2);
-            expect(cache.size).toBe(3);
+            expect(cache.size).toBe(4);
         });
 
         it('should not append any records when cache size is 0', () => {

--- a/src/plugins/cache/DefaultCache/defaultCache.spec.ts
+++ b/src/plugins/cache/DefaultCache/defaultCache.spec.ts
@@ -1,0 +1,320 @@
+import {DefaultCache} from "./index";
+import { ZoneData, SupportedAnswer, SupportedRecordType } from "../../../types/dns";
+
+describe('DefaultCache', () => {
+    let cache: DefaultCache;
+    
+    beforeEach(() => {
+        cache = new DefaultCache();
+    });
+    
+    describe('set', () => {
+        it('should set a single record', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'] = '127.0.0.1' ;
+    
+            cache.set(zone, rType, data);
+    
+            const result = cache.get(zone, rType);
+            expect(result).toEqual([data]);
+        });
+
+        it('should set multiple records', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+    
+            cache.set(zone, rType, data);
+    
+            const result = cache.get(zone, rType);
+            expect(result).toEqual(data);
+        });
+
+        it('should evict a random member when the cache is full', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'][] = Array.from({ length: 10 }, (_, i) => `127.0.0.${i + 1}`);
+            const domains = Array.from({ length: 10 }, (_, i) => `example${i}.com`);
+
+            const pairs = domains.map((domain, i) => [domain, data[i]] as [string, ZoneData['A']]);
+
+            pairs.forEach(([domain, record]) => cache.set(domain, rType, record));
+            const results = pairs.map(([domain, _]) => cache.get(domain, rType));
+            const filtered = results.filter(Boolean);
+            expect(filtered.length).toBe(3);
+            expect(cache.size).toBe(3);
+        });
+
+        it('should not set any records when cache size is 0', () => {
+            cache = new DefaultCache({ maxEntries: 0 });
+
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'] = '127.0.0.1';
+
+            cache.set(zone, rType, data);
+
+            const result = cache.get(zone, rType);
+
+            expect(result).toBe(null);
+
+            expect(cache.size).toBe(0);
+        });
+    });
+
+    describe('append', () => {
+        it('should append a single record', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'] = '127.0.0.1';
+    
+            cache.append(zone, rType, data);
+    
+            const result = cache.get(zone, rType);
+            expect(result).toEqual([data]);
+        });
+
+        it('should append multiple records', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data1: ZoneData['A'] = '127.0.0.1';
+            const data2: ZoneData['A'] = '127.0.0.2';
+    
+            cache.append(zone, rType, data1);
+            cache.append(zone, rType, data2);
+    
+            const result = cache.get(zone, rType);
+            expect(result).toEqual([data1, data2]);
+        });
+
+        it('should append to an existing record', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data1: ZoneData['A'] = '127.0.0.1';
+            const data2: ZoneData['A'] = '127.0.0.2';
+    
+            cache.set(zone, rType, data1);
+            cache.append(zone, rType, data2);
+    
+            const result = cache.get(zone, rType);
+            expect(result).toEqual([data1, data2]);
+        });
+
+        it('should append when the cache is full', () => {
+            const domains = Array.from({ length: 4 }, (_, i) => `example${i}.com`);
+            const data: ZoneData['A'][] = Array.from({ length: 4 }, (_, i) => `127.0.0.${i + 1}`);
+            const rType: SupportedRecordType = 'A';
+            const pairs = domains.map((domain, i) => [domain, data[i]] as [string, ZoneData['A']]);
+
+            pairs.forEach(([domain, record]) => {
+                cache.append(domain, rType, record);
+                cache.append(domain, rType, record);
+            });
+
+            const results = pairs.map(([domain, _]) => cache.get(domain, rType));
+            const filtered = results.filter(Boolean);
+            expect(filtered.length).toBe(3);
+
+            expect(filtered[0]!.length).toBe(2);
+            expect(cache.size).toBe(3);
+        });
+
+        it('should not append any records when cache size is 0', () => {
+            cache = new DefaultCache({ maxEntries: 0 });
+
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'] = '127.0.0.1';
+
+            cache.append(zone, rType, data);
+
+            const result = cache.get(zone, rType);
+
+            console.log(cache.cache);
+
+            expect(result).toBe(null);
+
+            expect(cache.size).toBe(0);
+
+        });
+    });
+
+    describe('get', () => {
+        it('Should get a single record', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'] = '127.0.0.1';
+
+            cache.set(zone, rType, data);
+
+            const result = cache.get(zone, rType);
+            expect(result).toEqual([data]);
+        });
+
+        it('Should get multiple records', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+
+            cache.set(zone, rType, data);
+
+            const result = cache.get(zone, rType);
+            expect(result).toEqual(data);
+        });
+
+        it('should return null when the zone does not exist', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+
+            const result = cache.get(zone, rType);
+            expect(result).toBe(null);
+        });
+
+        it('should return null when the record type does not exist', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+
+            cache.set(zone, rType, '127.0.0.1');
+
+            expect(cache.get(zone, 'A')).toEqual(['127.0.0.1']);
+            expect(cache.get(zone, 'AAAA')).toBe(null);
+        });
+    });
+
+    describe('delete', () => {
+        it('should delete a single record', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'] = '127.0.0.1';
+
+            cache.set(zone, rType, data);
+            expect(cache.get(zone, rType)).toEqual([data]);
+            cache.delete(zone, rType, data);
+
+            const result = cache.get(zone, rType);
+            expect(result).toBe(null);
+        });
+
+        it('should delete multiple records', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+
+            cache.set(zone, rType, data);
+            expect(cache.get(zone, rType)).toEqual(data);
+            cache.delete(zone, rType);
+            expect(cache.get(zone, rType)).toBe(null);
+        });
+
+        it('should delete a specific record', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+
+            cache.set(zone, rType, data);
+            expect(cache.get(zone, rType)).toEqual(data);
+            cache.delete(zone, rType, data[0]);
+            expect(cache.get(zone, rType)).toEqual([data[1]]);
+        });
+
+        it('should handle deleting a record that does not exist', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'] = '127.0.0.1'; 
+
+            cache.set(zone, rType, data);
+            expect(cache.get(zone, rType)).toEqual([data]);
+            cache.delete(zone, rType, '127.0.0.2');
+
+            const result = cache.get(zone, rType);
+            expect(result).toEqual([data]);
+        });
+
+        it('should handle deleting a record from an empty zone', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'] = '127.0.0.1';
+
+            cache.set(zone, rType, data);
+            
+            // don't throw an error deleting an empty zone
+            expect(() => cache.delete('example2.com', rType, '127.0.0.2')).not.toThrow();
+            
+            expect(cache.get(zone, rType)).toEqual([data]);
+        });
+
+    });
+
+    describe('eviction', () => {
+        it('should evict a random member', () => {
+            cache = new DefaultCache({ maxEntries: 1 });
+
+            const zones = ['example1.com', 'example2.com'];
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+
+            zones.forEach((zone, i) => cache.set(zone, rType, data[i]));
+
+            expect(cache.size).toBe(1);
+
+            const results = zones.map((zone) => cache.get(zone, rType));
+
+            expect(results.every(Boolean)).toBe(false);
+
+            cache.evictRandomMember();
+
+            expect(cache.size).toBe(0);
+        });
+
+        it('should evict until empty', () => {
+            cache = new DefaultCache({ maxEntries: 100 });
+
+            const zones = Array.from({ length: 100 }, (_, i) => `example${i}.com`);
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'][] = Array.from({ length: 100 }, (_, i) => `127.0.0.${i + 1}`);
+
+            zones.forEach((zone, i) => cache.set(zone, rType, data[i]));
+
+            expect(cache.size).toBe(100);
+
+            for (let i = 0; i < 100; i++) {
+                cache.evictRandomMember();
+
+                expect(cache.size).toBe(100 - i - 1);
+            }
+        });
+
+        it('should not error when evicting from an empty cache', () => {
+            cache = new DefaultCache({ maxEntries: 0 });
+
+            expect(() => cache.evictRandomMember()).not.toThrow();
+        });
+    }); 
+
+    describe('clear', () => {
+        it('should clear the cache', () => {
+            cache = new DefaultCache({ maxEntries: 100 });
+            const zones = Array.from({ length: 100 }, (_, i) => `example${i}.com`);
+            const rType: SupportedRecordType = 'A';
+            const data: ZoneData['A'][] = Array.from({ length: 100 }, (_, i) => `127.0.0.${i + 1}`);
+
+            zones.forEach((zone, i) => cache.set(zone, rType, data[i]));
+
+            expect(cache.size).toBe(100);
+
+            cache.clear();
+
+            expect(cache.size).toBe(0);
+        });
+    });
+
+    describe('getKey', () => {
+        it('should return the key for a zone and record type', () => {
+            const zone = 'example.com';
+            const rType: SupportedRecordType = 'A';
+
+            expect(DefaultCache.getKey(zone, rType)).toBe('example.com:A');
+        });
+    });
+});

--- a/src/plugins/cache/DefaultCache/index.ts
+++ b/src/plugins/cache/DefaultCache/index.ts
@@ -55,7 +55,7 @@ export class DefaultCache extends Cache {
     if (data) {
       const existing = this.cache.get(key) || [];
       const newRecords = existing.filter((d) => !_isEqual(d, data));
-      if(newRecords.length === 0) {
+      if (newRecords.length === 0) {
         this.cache.delete(key);
       } else {
         this.cache.set(key, newRecords);

--- a/src/plugins/cache/DefaultCache/index.ts
+++ b/src/plugins/cache/DefaultCache/index.ts
@@ -50,7 +50,6 @@ export class DefaultCache extends Cache {
 
   delete(zone: string, rType: SupportedRecordType, data?: ZoneData[SupportedRecordType]) {
     const key = DefaultCache.getKey(zone, rType);
-    const existing = this.cache.get(key) || [];
 
     if (data) {
       const existing = this.cache.get(key) || [];

--- a/src/plugins/cache/DefaultCache/index.ts
+++ b/src/plugins/cache/DefaultCache/index.ts
@@ -1,0 +1,108 @@
+import { Cache } from '../Cache';
+import { Handler } from '../../../types/server';
+import { ZoneData, SupportedRecordType, SupportedAnswer } from '../../../types/dns';
+import { isEqual as _isEqual } from 'lodash';
+
+export type DefaultCacheOptions = {
+  maxEntries?: number;
+};
+
+export class DefaultCache extends Cache {
+  cache: Map<string, ZoneData[keyof ZoneData][]> = new Map();
+  maxEntries: number | undefined;
+
+  constructor(options?: DefaultCacheOptions) {
+    super();
+    this.maxEntries = options?.maxEntries;
+  }
+
+  get<T extends SupportedRecordType>(zone: string, rType: T): ZoneData[T][] | ZoneData[keyof ZoneData][] | null {
+    const key = DefaultCache.getKey(zone, rType);
+    return this.cache.get(key) || null;
+  }
+
+  set<T extends SupportedRecordType>(zone: string, rType: T, data: ZoneData[T] | ZoneData[keyof ZoneData][]) {
+    if (this.maxEntries === 0) return;
+
+    if (!Array.isArray(data)) {
+      data = [data];
+    }
+
+    if (this.maxEntries && this.cache.size >= this.maxEntries) {
+      this.evictRandomMember();
+    }
+
+    const key = DefaultCache.getKey(zone, rType);
+    this.cache.set(key, data);
+  }
+
+  append(zone: string, rType: SupportedRecordType, data: ZoneData[SupportedRecordType]) {
+    if (this.maxEntries === 0) return;
+
+    const key = DefaultCache.getKey(zone, rType);
+    const existing = this.cache.get(key) || [];
+    this.cache.set(key, [...existing, data]);
+
+    if (this.maxEntries && this.cache.size > this.maxEntries) {
+      this.evictRandomMember();
+    }
+  }
+
+  delete(zone: string, rType: SupportedRecordType, data?: ZoneData[SupportedRecordType]) {
+    const key = DefaultCache.getKey(zone, rType);
+    const existing = this.cache.get(key) || [];
+
+    if (data) {
+      const existing = this.cache.get(key) || [];
+      const newRecords = existing.filter((d) => !_isEqual(d, data));
+      if(newRecords.length === 0) {
+        this.cache.delete(key);
+      } else {
+        this.cache.set(key, newRecords);
+      }
+    } else {
+      this.cache.delete(key);
+    }
+  }
+
+  get size() {
+    return this.cache.size;
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+
+  handler: Handler = async (req, res, next) => {
+    if (res.finished) {
+      return next();
+    }
+
+    const { name, type } = req.packet.questions[0];
+    const data = this.get(name, type);
+
+    const answers: SupportedAnswer[] | undefined = data?.map(
+      (d) =>
+        ({
+          name,
+          type,
+          data: d,
+        }) as SupportedAnswer,
+    );
+
+    if (answers) {
+      res.answer(answers);
+    }
+
+    next();
+  };
+
+  evictRandomMember() {
+    const key = Array.from(this.cache.keys())[Math.floor(Math.random() * this.cache.size)];
+    this.cache.delete(key);
+  }
+
+  static getKey(zone: string, rType: SupportedRecordType) {
+    return `${zone}:${rType}`;
+  }
+}

--- a/src/plugins/cache/DefaultCache/index.ts
+++ b/src/plugins/cache/DefaultCache/index.ts
@@ -14,6 +14,8 @@ export class DefaultCache extends Cache {
   constructor(options?: DefaultCacheOptions) {
     super();
     this.maxEntries = options?.maxEntries;
+
+    this.handler = this.handler.bind(this);
   }
 
   get<T extends SupportedRecordType>(zone: string, rType: T): ZoneData[T][] | ZoneData[keyof ZoneData][] | null {

--- a/src/plugins/cache/index.ts
+++ b/src/plugins/cache/index.ts
@@ -1,0 +1,2 @@
+export { DefaultCache } from './DefaultCache';
+export { Cache } from './Cache';

--- a/src/plugins/storage/DefaultStore/index.ts
+++ b/src/plugins/storage/DefaultStore/index.ts
@@ -108,6 +108,10 @@ export class DefaultStore extends EventEmitter implements Store {
   }
 
   handler(req: DNSRequest, res: DNSResponse, next: NextFunction) {
+    if (res.finished) {
+      return next();
+    }
+
     const { questions } = req.packet;
     const { name, type } = questions![0];
 


### PR DESCRIPTION
Implement basic cache interface and add DefaultCache plugin.

Caches differ from Storage plugins in that they are designed to provide O(1) lookups at all times. Concretely, unlike Storage plugins, which allow for some nested data structures like `Map<DomainName, Map<RecordType, RecordData>>`, caches should be flat and the keys should indicate the domain name and record type.

It should also be noted that currently cache sizes refer to the number of RRsets stored, not the number of unique records -- theoretically, if an A record for a particular domain has thousands of stored records, this would only be counted as one record.

It should also be noted that this PR fixed a potential bug in the Storage plugin. More generally, it should be enforced that _any time a middleware sends a response back to the client, it should first check to see if the response has already been sent_. It's possible we will want to add this as a configurable setting in the server, as this is a slightly annoying bug to run into every time you write middleware.