### PR TITLE
Improvement/correct timestamps

### DIFF
--- a/src/common/core/events.ts
+++ b/src/common/core/events.ts
@@ -1,0 +1,27 @@
+import {EventEmitter} from 'events';
+
+export class TypedEventEmitter<T> extends EventEmitter {
+    override on<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
+        return super.on(event, listener);
+    }
+
+    override emit<K extends keyof T & string>(event: K, arg: T[K]): boolean {
+        return super.emit(event, arg);
+    }
+
+    override off<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
+        return super.off(event, listener);
+    }
+
+    override once<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
+        return super.once(event, listener);
+    }
+
+    override addListener<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
+        return super.addListener(event, listener);
+    }
+
+    override removeListener<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
+        return super.removeListener(event, listener);
+    }
+}

--- a/src/common/core/events.ts
+++ b/src/common/core/events.ts
@@ -1,27 +1,27 @@
-import {EventEmitter} from 'events';
+import { EventEmitter } from 'events';
 
 export class TypedEventEmitter<T> extends EventEmitter {
-    override on<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
-        return super.on(event, listener);
-    }
+  override on<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
+    return super.on(event, listener);
+  }
 
-    override emit<K extends keyof T & string>(event: K, arg: T[K]): boolean {
-        return super.emit(event, arg);
-    }
+  override emit<K extends keyof T & string>(event: K, arg: T[K]): boolean {
+    return super.emit(event, arg);
+  }
 
-    override off<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
-        return super.off(event, listener);
-    }
+  override off<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
+    return super.off(event, listener);
+  }
 
-    override once<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
-        return super.once(event, listener);
-    }
+  override once<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
+    return super.once(event, listener);
+  }
 
-    override addListener<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
-        return super.addListener(event, listener);
-    }
+  override addListener<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
+    return super.addListener(event, listener);
+  }
 
-    override removeListener<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
-        return super.removeListener(event, listener);
-    }
+  override removeListener<K extends keyof T & string>(event: K, listener: (arg: T[K]) => void): this {
+    return super.removeListener(event, listener);
+  }
 }

--- a/src/common/network/net.ts
+++ b/src/common/network/net.ts
@@ -1,8 +1,8 @@
 import type { Serializer } from '../serializer';
-import type { DNSResponse } from '../../types/server';
+import type { DNSRequest, DNSResponse } from '../../types/server';
 
-export interface NetworkHandler<T> {
-  (data: T, connection: Connection): Promise<DNSResponse>;
+export interface NetworkHandler {
+  (request: DNSRequest): Promise<DNSResponse>;
 }
 /**
  * Network defines the interaction layer between the server and the network.
@@ -46,7 +46,7 @@ export interface Network<T> {
   /**
    * The handler is responsible for processing incoming requests and sending outgoing responses.
    */
-  handler?: NetworkHandler<T>;
+  handler?: NetworkHandler;
 
   /**
    * Passes the listener to the underlying network interface which may be an event emitter.

--- a/src/common/network/tcp.ts
+++ b/src/common/network/tcp.ts
@@ -74,6 +74,8 @@ export class DNSOverTCP implements Network<dnsPacket.Packet> {
 
           const packet = dnsPacket.streamDecode(data);
           const request = new DNSRequest(packet, this.toConnection(socket));
+          request.metadata.ts.requestTimeNs = startTime; // override the request time with the time the request was received
+          request.metadata.ts.requestTimeMs = startTimeMs; // override the request time with the time the request was received
           const response = await this.handler(request);
           if (!socketEnded) {
             socket.write(new Uint8Array(this.serializer.encode(response.packet.raw)), (err) => {

--- a/src/common/network/tcp.ts
+++ b/src/common/network/tcp.ts
@@ -59,7 +59,7 @@ export class DNSOverTCP implements Network<dnsPacket.Packet> {
         }
         const packet = dnsPacket.streamDecode(data);
         const request = new DNSRequest(packet, this.toConnection(socket));
-        request.metadata.ts.requestTimeNs = startTime; 
+        request.metadata.ts.requestTimeNs = startTime;
         request.metadata.ts.requestTimeMs = startTimeMs;
 
         this.handler(request)

--- a/src/common/network/udp.ts
+++ b/src/common/network/udp.ts
@@ -100,7 +100,7 @@ export class DNSOverUDP implements Network<dnsPacket.Packet> {
           this.server.send(new Uint8Array(this.serializer.encode(resp.packet.raw)), rinfo.port, rinfo.address);
           return resp;
         })
-        .then(resp => {
+        .then((resp) => {
           const endTime = process.hrtime.bigint();
           const endTimeMs = Date.now();
           resp.metadata.ts.responseTimeNs = endTime;

--- a/src/common/network/udp.ts
+++ b/src/common/network/udp.ts
@@ -3,6 +3,7 @@ import { Serializer } from '../serializer';
 import dgram from 'dgram';
 import dnsPacket, { TRUNCATED_RESPONSE } from 'dns-packet';
 import { RCode, CombineFlags } from '../core/utils';
+import { DNSRequest } from '../../types';
 
 /**
  * Serializer for the UDP protocol. The `dns-packet` module's
@@ -65,7 +66,7 @@ export class DNSOverUDP implements Network<dnsPacket.Packet> {
   private server: dgram.Socket;
   public serializer: UDPSerializer;
   public networkType: SupportedNetworkType = SupportedNetworkType.UDP;
-  public handler?: NetworkHandler<dnsPacket.Packet>;
+  public handler?: NetworkHandler;
 
   constructor({ address, port, serializer }: DNSOverUDPProps) {
     this.address = address;
@@ -74,6 +75,8 @@ export class DNSOverUDP implements Network<dnsPacket.Packet> {
     this.serializer = serializer || new UDPSerializer();
 
     this.server.on('message', async (msg, rinfo) => {
+      const startTime = process.hrtime.bigint();
+      const startTimeMs = Date.now();
       if (!this.handler) {
         const response = dnsPacket.encode({
           type: 'response',
@@ -89,9 +92,21 @@ export class DNSOverUDP implements Network<dnsPacket.Packet> {
       }
 
       const packet = this.serializer.decode(msg);
-      this.handler(packet, this.toConnection(rinfo))
+      const request = new DNSRequest(packet, this.toConnection(rinfo));
+      request.metadata.ts.requestTimeNs = startTime;
+      request.metadata.ts.requestTimeMs = startTimeMs;
+      this.handler(request)
         .then((resp) => {
           this.server.send(new Uint8Array(this.serializer.encode(resp.packet.raw)), rinfo.port, rinfo.address);
+          return resp;
+        })
+        .then(resp => {
+          const endTime = process.hrtime.bigint();
+          const endTimeMs = Date.now();
+          resp.metadata.ts.responseTimeNs = endTime;
+          resp.metadata.ts.responseTimeMs = endTimeMs;
+          resp.emit('done', resp);
+          resp.removeAllListeners(); // cleanup
         })
         .catch((err) => {
           console.error(err);

--- a/src/common/server/DefaultServer.ts
+++ b/src/common/server/DefaultServer.ts
@@ -49,12 +49,10 @@ export class DefaultServer implements DNSServer<dnsPacket.Packet> {
     }
 
     for (const network of this.networks) {
-      network.handler = async (packet, connection) => {
-        const req = new DNSRequest(packet, connection);
+      network.handler = async (req) => {
         const res: DNSResponse = req.toAnswer();
-
         return await new Promise<DNSResponse>((resolve) => {
-          res.once('done', () => {
+          res.once('answer', (res) => {
             resolve(res);
           });
 

--- a/src/examples/helloWorld/index.ts
+++ b/src/examples/helloWorld/index.ts
@@ -1,6 +1,6 @@
 import { ConsoleLogger } from '../../plugins/loggers';
 import { DefaultStore } from '../../plugins/storage';
-import { DNSOverTCP, DNSOverUDP, DefaultServer } from '../../common';
+import { DNSOverTCP, DNSOverUDP, DefaultServer, DNSOverHTTP } from '../../common';
 import fs from 'fs';
 
 const logger = new ConsoleLogger(true, true);
@@ -16,6 +16,8 @@ const s = new DefaultServer({
     new DNSOverTCP({ address: 'localhost', port: 1054 }),
     new DNSOverUDP({ address: 'localhost', port: 1054 }),
     new DNSOverTCP({ address: 'localhost', port: 1853, ssl: sslConfig }),
+    new DNSOverHTTP({ address: 'localhost', port: 1080 }),
+    new DNSOverHTTP({ address: 'localhost', port: 1443, ssl: sslConfig }),
   ],
 });
 

--- a/src/examples/helloWorld/index.ts
+++ b/src/examples/helloWorld/index.ts
@@ -13,11 +13,11 @@ const sslConfig = {
 };
 const s = new DefaultServer({
   networks: [
-    new DNSOverTCP({ address: 'localhost', port: 1054 }),
-    new DNSOverUDP({ address: 'localhost', port: 1054 }),
-    new DNSOverTCP({ address: 'localhost', port: 1853, ssl: sslConfig }),
-    new DNSOverHTTP({ address: 'localhost', port: 1080 }),
-    new DNSOverHTTP({ address: 'localhost', port: 1443, ssl: sslConfig }),
+    new DNSOverTCP({ address: '0.0.0.0', port: 1054 }),
+    new DNSOverUDP({ address: '0.0.0.0', port: 1054 }),
+    new DNSOverTCP({ address: '0.0.0.0', port: 1853, ssl: sslConfig }),
+    new DNSOverHTTP({ address: '0.0.0.0', port: 1080 }),
+    new DNSOverHTTP({ address: '0.0.0.0', port: 1443, ssl: sslConfig }),
   ],
 });
 

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -1,7 +1,6 @@
 import dnsPacket from 'dns-packet';
 import { Connection } from '../common/network';
 import { CombineFlags, RCode } from '../common/core/utils';
-import { EventEmitter } from 'events';
 import { SupportedAnswer, SupportedQuestion } from '../types/dns';
 import _cloneDeep from 'lodash/cloneDeep';
 import { TypedEventEmitter } from '../common/core/events';


### PR DESCRIPTION
See #25 

This pull request introduces several enhancements and refactorings to improve the event handling system and network request processing. The key changes include the creation of a `TypedEventEmitter` class, updates to network handler interfaces, and the addition of request timing metadata.

### Event Handling Improvements:
* [`src/common/core/events.ts`](diffhunk://#diff-30770d243a914f207c568c70b6f38afa4479163654530b15d13caf65e9eb051eR1-R27): Introduced `TypedEventEmitter` class to provide type-safe event handling.
* [`src/types/server.ts`](diffhunk://#diff-c383c3e4dc1b847209ec10cf2f75e63f1e5535a0637079bf3d77ad56677184f5R7): Updated `DNSResponse` to extend `TypedEventEmitter` and added `DNSResponseEvents` interface for type-safe events. [[1]](diffhunk://#diff-c383c3e4dc1b847209ec10cf2f75e63f1e5535a0637079bf3d77ad56677184f5R7) [[2]](diffhunk://#diff-c383c3e4dc1b847209ec10cf2f75e63f1e5535a0637079bf3d77ad56677184f5R204-R214) [[3]](diffhunk://#diff-c383c3e4dc1b847209ec10cf2f75e63f1e5535a0637079bf3d77ad56677184f5L246-R252)

### Network Handler Refactoring:
* [`src/common/network/net.ts`](diffhunk://#diff-b9eed725feeefd8e0b29705d90449ac83765106be645e892c30f62127cd8001eL2-R5): Updated `NetworkHandler` interface to accept a `DNSRequest` object instead of individual parameters. [[1]](diffhunk://#diff-b9eed725feeefd8e0b29705d90449ac83765106be645e892c30f62127cd8001eL2-R5) [[2]](diffhunk://#diff-b9eed725feeefd8e0b29705d90449ac83765106be645e892c30f62127cd8001eL49-R49)
* [`src/common/network/http.ts`](diffhunk://#diff-0c3a32da6e8e9d5deff26d173095eb1a087c82e564ccc887b1533791c80945e6L23-R24): Modified `DNSOverHTTP` to use the updated `NetworkHandler` interface and added request timing metadata. [[1]](diffhunk://#diff-0c3a32da6e8e9d5deff26d173095eb1a087c82e564ccc887b1533791c80945e6L23-R24) [[2]](diffhunk://#diff-0c3a32da6e8e9d5deff26d173095eb1a087c82e564ccc887b1533791c80945e6R96-R98) [[3]](diffhunk://#diff-0c3a32da6e8e9d5deff26d173095eb1a087c82e564ccc887b1533791c80945e6L142-R159)
* [`src/common/network/tcp.ts`](diffhunk://#diff-9632900f3b3a46d448f9bcdca39e8d907dc8267f5047c81978b84382c78b4607L38-R39): Updated `DNSOverTCP` to use the new `NetworkHandler` interface and added request timing metadata. [[1]](diffhunk://#diff-9632900f3b3a46d448f9bcdca39e8d907dc8267f5047c81978b84382c78b4607L38-R39) [[2]](diffhunk://#diff-9632900f3b3a46d448f9bcdca39e8d907dc8267f5047c81978b84382c78b4607R50-R51) [[3]](diffhunk://#diff-9632900f3b3a46d448f9bcdca39e8d907dc8267f5047c81978b84382c78b4607L58-R76)
* [`src/common/network/udp.ts`](diffhunk://#diff-1a1c89d34ae3a05a6e88d1aa732d400d1aa84f3a7471e465486bc536c4db0ee8L68-R69): Adjusted `DNSOverUDP` to utilize the updated `NetworkHandler` interface and included request timing metadata. [[1]](diffhunk://#diff-1a1c89d34ae3a05a6e88d1aa732d400d1aa84f3a7471e465486bc536c4db0ee8L68-R69) [[2]](diffhunk://#diff-1a1c89d34ae3a05a6e88d1aa732d400d1aa84f3a7471e465486bc536c4db0ee8R78-R79) [[3]](diffhunk://#diff-1a1c89d34ae3a05a6e88d1aa732d400d1aa84f3a7471e465486bc536c4db0ee8L92-R109)

### Example Update:
* [`src/examples/helloWorld/index.ts`](diffhunk://#diff-74f6deb180997afe8bd5091c75305002836319f55fb11f28c0240a64884257c2L3-R3): Added `DNSOverHTTP` examples to the helloWorld example setup. [[1]](diffhunk://#diff-74f6deb180997afe8bd5091c75305002836319f55fb11f28c0240a64884257c2L3-R3) [[2]](diffhunk://#diff-74f6deb180997afe8bd5091c75305002836319f55fb11f28c0240a64884257c2R19-R20)