### PR TITLE
Update PacketWrapper to support authorities

### DIFF
--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -132,7 +132,7 @@ export class PacketWrapper {
     if (this.frozen) {
       throw new ModifiedAfterSentError();
     }
-    this.raw.answers = answers || [];
+    this.raw.answers = answers;
   }
 
   get additionals(): ReadonlyArray<dnsPacket.Answer> {
@@ -143,7 +143,18 @@ export class PacketWrapper {
     if (this.frozen) {
       throw new ModifiedAfterSentError();
     }
-    this.raw.additionals = additionals || [];
+    this.raw.additionals = additionals;
+  }
+
+  get authorities(): ReadonlyArray<dnsPacket.Answer> {
+    return (this.raw.authorities || []) as ReadonlyArray<dnsPacket.Answer>;
+  }
+
+  set authorities(authority: dnsPacket.Answer[]) {
+    if (this.frozen) {
+      throw new ModifiedAfterSentError();
+    }
+    this.raw.authorities = authority;
   }
 
   /**


### PR DESCRIPTION
Addresses #29 .

This pull request includes changes to the `PacketWrapper` class in the `src/types/server.ts` file, focusing on the handling of DNS packet properties. The most important changes are the removal of default empty array assignments and the addition of getter and setter methods for the `authorities` property.

Changes to `PacketWrapper` class:

* Removed default empty array assignments for `answers` and `additionals` properties. (`src/types/server.ts`, [[1]](diffhunk://#diff-c383c3e4dc1b847209ec10cf2f75e63f1e5535a0637079bf3d77ad56677184f5L135-R135) [[2]](diffhunk://#diff-c383c3e4dc1b847209ec10cf2f75e63f1e5535a0637079bf3d77ad56677184f5L146-R157)
* Added getter and setter methods for the `authorities` property, including a check to prevent modification if the packet is frozen. (`src/types/server.ts`, [src/types/server.tsL146-R157](diffhunk://#diff-c383c3e4dc1b847209ec10cf2f75e63f1e5535a0637079bf3d77ad56677184f5L146-R157))