### PR TITLE
Fix err_stream_write_after_end

### DIFF
--- a/src/common/network/tcp.ts
+++ b/src/common/network/tcp.ts
@@ -73,7 +73,7 @@ export class DNSOverTCP implements Network<dnsPacket.Packet> {
           const response = await this.handler(packet, this.toConnection(socket));
           if (!socketEnded) {
             socket.write(new Uint8Array(this.serializer.encode(response.packet.raw)), (err) => {
-            endSocket(err);
+              endSocket(err);
             });
           }
         } catch (err) {


### PR DESCRIPTION
In situations when the server underwent high levels of concurrency, it would almost immediately begin encountering ERR_STREAM_WRITE_AFTER_END errors. These, fortunately, didn't crash the server, but obviously were a bit problematic.

This pull request includes a significant update to the `DNSOverTCP` class in the `src/common/network/tcp.ts` file fixing these errors and improving error handling and ensuring proper socket closure.

Key changes include:

### Error Handling and Socket Management:

* Introduced a `socketEnded` flag to prevent multiple attempts to end the same socket.
* Added an `endSocket` function to centralize socket closure logic and error logging.
* Modified the `data` event handler to use `endSocket` for error handling and to ensure the socket is closed properly after data processing.
* Updated the `error` and `end` event handlers to use the new `endSocket` function for consistent socket closure.

These changes enhance the robustness of the `DNSOverTCP` class by ensuring that sockets are closed correctly and errors are handled more gracefully.