### PR TITLE
Support multithreading via Nodejs's built-in cluster mode

### DIFF
--- a/src/common/server/DefaultServer.ts
+++ b/src/common/server/DefaultServer.ts
@@ -3,6 +3,8 @@ import { Network } from '../network';
 import { Handler } from '../../types/server';
 import { DefaultRouter, Router } from '../router';
 import dnsPacket from 'dns-packet';
+import cluster from 'cluster';
+import os from 'os';
 
 export interface DNSServer<PacketType> {
   networks: Network<PacketType>[];
@@ -25,6 +27,12 @@ export type DefaultServerProps<PacketType> = {
 
   /** The default handler used if no handler answers the query. Default behavior is NXDOMAIN response. */
   defaultHandler?: Handler;
+
+  /** Whether the server should run multithreaded in cluster mode.
+   *
+   * For more information, see the nodejs docs on [cluster mode](https://nodejs.org/api/cluster.html)
+   */
+  multithreaded?: boolean;
 };
 
 /**
@@ -39,10 +47,12 @@ export type DefaultServerProps<PacketType> = {
 export class DefaultServer implements DNSServer<dnsPacket.Packet> {
   public networks: Network<dnsPacket.Packet>[] = [];
   private router: Router;
+  public multithreaded: boolean;
 
   constructor(props: DefaultServerProps<dnsPacket.Packet>) {
     this.networks = props.networks;
     this.router = props.router || new DefaultRouter();
+    this.multithreaded = props.multithreaded || false;
 
     if (props.defaultHandler) {
       this.default = props.defaultHandler;
@@ -117,12 +127,26 @@ export class DefaultServer implements DNSServer<dnsPacket.Packet> {
   }
 
   start(callback?: () => void): void {
-    for (const network of this.networks) {
-      network.listen();
-    }
+    if (this.multithreaded && cluster.isPrimary) {
+      const numCpus = os.cpus().length;
 
-    if (callback) {
-      callback();
+      for (let i = 0; i < numCpus; i++) {
+        cluster.fork();
+      }
+
+      cluster.on('exit', (worker, code, signal) => {
+        console.log(`worker ${worker.process.pid} died, exiting with code ${code} and signal ${signal}`);
+        console.log('respawning worker...');
+        cluster.fork(); // respawn worker
+      });
+    } else {
+      for (const network of this.networks) {
+        network.listen();
+      }
+
+      if (callback) {
+        callback();
+      }
     }
   }
 

--- a/src/common/server/DefaultServer.ts
+++ b/src/common/server/DefaultServer.ts
@@ -49,13 +49,18 @@ export class DefaultServer implements DNSServer<dnsPacket.Packet> {
   private router: Router;
   public multithreaded: boolean;
 
-  constructor(props: DefaultServerProps<dnsPacket.Packet>) {
-    this.networks = props.networks;
-    this.router = props.router || new DefaultRouter();
-    this.multithreaded = props.multithreaded || false;
+  constructor({
+    networks,
+    router = new DefaultRouter(),
+    multithreaded = false,
+    defaultHandler,
+  }: DefaultServerProps<dnsPacket.Packet>) {
+    this.networks = networks;
+    this.router = router;
+    this.multithreaded = multithreaded;
 
-    if (props.defaultHandler) {
-      this.default = props.defaultHandler;
+    if (defaultHandler) {
+      this.default = defaultHandler;
     }
 
     for (const network of this.networks) {

--- a/src/examples/cluster/index.ts
+++ b/src/examples/cluster/index.ts
@@ -1,0 +1,33 @@
+import { DefaultServer, DNSOverUDP, DNSOverTCP, DNSOverHTTP } from '../../common';
+import { DefaultStore } from '../../plugins/storage';
+import process from 'process';
+
+const store = new DefaultStore();
+store.set('example.com', 'A', '127.0.0.1');
+const server = new DefaultServer({
+  networks: [
+    new DNSOverUDP({
+      address: '0.0.0.0',
+      port: 1053,
+    }),
+    new DNSOverTCP({
+      address: '0.0.0.0',
+      port: 1053,
+    }),
+    new DNSOverHTTP({
+      address: '0.0.0.0',
+      port: 1080,
+    }),
+  ],
+  multithreaded: true,
+});
+
+server.use((req, res, next) => {
+  console.log(`[${process.pid}] ${req.packet.questions[0].name}`);
+  next();
+});
+server.use(store.handler);
+
+server.start(() => {
+  console.log(`Server started in cluster mode on PID ${process.pid}`);
+});


### PR DESCRIPTION
This pull request introduces the capability for the `DefaultServer` to run in a multithreaded cluster mode, enhancing its performance and scalability. The key changes involve adding cluster and OS modules, updating the server properties to include a multithreaded option, and modifying the server's start method to support clustering.

### Enhancements to `DefaultServer`:

* [`src/common/server/DefaultServer.ts`](diffhunk://#diff-e4d11135171e4642979439123f43d205b57a9b7b5a897e6c1365ac89f5718e57R6-R7): Imported the `cluster` and `os` modules to enable cluster mode functionality.
* [`src/common/server/DefaultServer.ts`](diffhunk://#diff-e4d11135171e4642979439123f43d205b57a9b7b5a897e6c1365ac89f5718e57R30-R35): Added a `multithreaded` property to the `DefaultServerProps` type and the `DefaultServer` class to allow configuration of the server's multithreaded mode. [[1]](diffhunk://#diff-e4d11135171e4642979439123f43d205b57a9b7b5a897e6c1365ac89f5718e57R30-R35) [[2]](diffhunk://#diff-e4d11135171e4642979439123f43d205b57a9b7b5a897e6c1365ac89f5718e57R50-R55)
* [`src/common/server/DefaultServer.ts`](diffhunk://#diff-e4d11135171e4642979439123f43d205b57a9b7b5a897e6c1365ac89f5718e57R130-R142): Modified the `start` method to fork worker processes based on the number of CPUs when `multithreaded` is enabled, and to handle worker exits by respawning new workers. [[1]](diffhunk://#diff-e4d11135171e4642979439123f43d205b57a9b7b5a897e6c1365ac89f5718e57R130-R142) [[2]](diffhunk://#diff-e4d11135171e4642979439123f43d205b57a9b7b5a897e6c1365ac89f5718e57R151)

### Example usage:

* [`src/examples/cluster/index.ts`](diffhunk://#diff-f1310c8560957f853c3ec4da400861869b1d52d529458623247565062f03c85fR1-R33): Added a new example demonstrating how to configure and start a `DefaultServer` in cluster mode, including setting up DNS over UDP, TCP, and HTTP networks, and using a custom handler to log requests.