### PR TITLE
Add back in port and address to network

### DIFF
--- a/src/common/network/net.ts
+++ b/src/common/network/net.ts
@@ -16,6 +16,12 @@ export interface Network<T> {
   /** The type of network being used */
   networkType: SupportedNetworkType;
 
+  /** The address the network should bind to */
+  address: string;
+
+  /** The port the network should listen on */
+  port: number;
+
   /**
    * The serializer is responsible for encoding and decoding packets.
    * This is the piece of logic responsible for communicating directly with the wire format

--- a/src/examples/helloWorld/index.ts
+++ b/src/examples/helloWorld/index.ts
@@ -25,5 +25,7 @@ s.use(logger.handler.bind(logger));
 s.use(st.handler);
 
 s.start(() => {
-  console.log('Server started, using protocols:' + s.networks.map((n) => n.networkType).join(', '));
+  s.networks.map((n) => {
+    console.log(`Listening over ${n.networkType} on ${n.address}:${n.port}`);
+  });
 });


### PR DESCRIPTION
Previously, we had removed `port` and `address` properties from the networks interface under the assumption that we may want networks in the future to be implementation-agnostic -- that is, perhaps the HTTP network would want to act as both HTTP and HTTPS at the same time, and would therefore need multiple ports.

However, this PR adds those fields back in with an opinionated patch that networks should only serve one purpose.

Also includes an unrelated type definition correction on the logger (not sure why I did that here).

Enhancements to network configuration:

* [`src/common/network/net.ts`](diffhunk://#diff-b9eed725feeefd8e0b29705d90449ac83765106be645e892c30f62127cd8001eR19-R24): Added `address` and `port` properties to the `Network` interface to specify the network binding address and listening port.

Improvements to logging functionality:

* [`src/examples/helloWorld/index.ts`](diffhunk://#diff-74f6deb180997afe8bd5091c75305002836319f55fb11f28c0240a64884257c2L28-R30): Updated the server start log to display the network type, address, and port for each network.