### PR TITLE
Retype the storage interface to support clearer outputs

### DIFF
--- a/src/plugins/storage/DefaultStore/defaultStore.spec.ts
+++ b/src/plugins/storage/DefaultStore/defaultStore.spec.ts
@@ -43,7 +43,7 @@ describe('MapStore', () => {
       expect(store.get('test.example.com', 'A')).toEqual(ARecordAnswer);
       expect(store.get('test.example.com', 'AAAA')).toEqual(AAAARecordAnswer);
 
-      expect(store.get('test.example.com')).toEqual({...ARecordAnswer, ...AAAARecordAnswer});
+      expect(store.get('test.example.com')).toEqual({ ...ARecordAnswer, ...AAAARecordAnswer });
     });
 
     it('should be able to get a wildcard record with specific rType when the data does not exist', async () => {
@@ -85,7 +85,7 @@ describe('MapStore', () => {
     it('should be able to append to an empty record', async () => {
       store.append('example.com', 'A', ARecords[0]);
 
-      expect(store.get('example.com', 'A')).toEqual({A: [ARecords[0]]});
+      expect(store.get('example.com', 'A')).toEqual({ A: [ARecords[0]] });
     });
   });
 
@@ -101,7 +101,7 @@ describe('MapStore', () => {
       store.set('example.com', 'A', ARecords);
       store.delete('example.com', 'A', ARecords[0]);
 
-      expect(store.get('example.com', 'A')).toEqual({A: [ARecords[1]]});
+      expect(store.get('example.com', 'A')).toEqual({ A: [ARecords[1]] });
     });
 
     it('should be able to delete a whole record', async () => {
@@ -117,7 +117,7 @@ describe('MapStore', () => {
       store.set('example.com', 'AAAA', AAAARecords);
       store.delete('example.com', 'A', ARecords[0]);
 
-      expect(store.get('example.com', 'A')).toEqual({A: [ARecords[1]]});
+      expect(store.get('example.com', 'A')).toEqual({ A: [ARecords[1]] });
       expect(store.get('example.com', 'AAAA')).toEqual(AAAARecordAnswer);
     });
 
@@ -146,7 +146,7 @@ describe('MapStore', () => {
     it('should clean up the key if no records are left', async () => {
       store.set('example.com', 'A', ARecords);
       store.delete('example.com', 'A', ARecords[0]);
-      expect(store.get('example.com', 'A')).toEqual({A: [ARecords[1]]});
+      expect(store.get('example.com', 'A')).toEqual({ A: [ARecords[1]] });
       store.delete('example.com', 'A', ARecords[1]);
 
       expect(store.get('example.com')).toEqual(null);

--- a/src/plugins/storage/DefaultStore/defaultStore.spec.ts
+++ b/src/plugins/storage/DefaultStore/defaultStore.spec.ts
@@ -1,10 +1,12 @@
 import { DefaultStore } from '.';
-import { ZoneData } from '../../../types/dns';
+import { ZoneData, DataMap } from '../../../types/dns';
 
 describe('MapStore', () => {
   let store: DefaultStore;
   const ARecords: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
+  const ARecordAnswer: Partial<DataMap> = { A: ARecords };
   const AAAARecords: ZoneData['AAAA'][] = ['::1', '::2'];
+  const AAAARecordAnswer: Partial<DataMap> = { AAAA: AAAARecords };
 
   beforeEach(() => {
     store = new DefaultStore();
@@ -22,10 +24,10 @@ describe('MapStore', () => {
       store.set('example.com', 'A', ARecords);
       store.set('example.com', 'AAAA', AAAARecords);
 
-      expect(store.get('example.com', 'A')).toEqual(ARecords);
-      expect(store.get('example.com', 'AAAA')).toEqual(AAAARecords);
+      expect(store.get('example.com', 'A')).toEqual(ARecordAnswer);
+      expect(store.get('example.com', 'AAAA')).toEqual(AAAARecordAnswer);
 
-      expect(store.get('example.com')).toEqual([...ARecords, ...AAAARecords]);
+      expect(store.get('example.com')).toEqual({ ...ARecordAnswer, ...AAAARecordAnswer });
     });
 
     it('should not return data if wildcards are disabled', async () => {
@@ -38,10 +40,10 @@ describe('MapStore', () => {
       store.set('*.example.com', 'A', ARecords);
       store.set('*.example.com', 'AAAA', AAAARecords);
 
-      expect(store.get('test.example.com', 'A')).toEqual(ARecords);
-      expect(store.get('test.example.com', 'AAAA')).toEqual(AAAARecords);
+      expect(store.get('test.example.com', 'A')).toEqual(ARecordAnswer);
+      expect(store.get('test.example.com', 'AAAA')).toEqual(AAAARecordAnswer);
 
-      expect(store.get('test.example.com')).toEqual([...ARecords, ...AAAARecords]);
+      expect(store.get('test.example.com')).toEqual({...ARecordAnswer, ...AAAARecordAnswer});
     });
 
     it('should be able to get a wildcard record with specific rType when the data does not exist', async () => {
@@ -55,13 +57,13 @@ describe('MapStore', () => {
     it('should be able to set a single record', async () => {
       store.set('example.com', 'A', ARecords[0]);
 
-      expect(store.get('example.com', 'A')).toEqual([ARecords[0]]);
+      expect(store.get('example.com', 'A')).toEqual({ A: [ARecords[0]] });
     });
 
     it('should be able to set an array of records', async () => {
       store.set('example.com', 'A', ARecords);
 
-      expect(store.get('example.com', 'A')).toEqual(ARecords);
+      expect(store.get('example.com', 'A')).toEqual(ARecordAnswer);
     });
   });
 
@@ -70,20 +72,20 @@ describe('MapStore', () => {
       store.set('example.com', 'A', ARecords[0]);
       store.append('example.com', 'A', ARecords[1]);
 
-      expect(store.get('example.com', 'A')).toEqual(ARecords);
+      expect(store.get('example.com', 'A')).toEqual(ARecordAnswer);
     });
 
     it('should be able to append an array of records', async () => {
       store.set('example.com', 'A', ARecords[0]);
       store.append('example.com', 'A', ARecords[1]);
 
-      expect(store.get('example.com', 'A')).toEqual(ARecords);
+      expect(store.get('example.com', 'A')).toEqual(ARecordAnswer);
     });
 
     it('should be able to append to an empty record', async () => {
       store.append('example.com', 'A', ARecords[0]);
 
-      expect(store.get('example.com', 'A')).toEqual([ARecords[0]]);
+      expect(store.get('example.com', 'A')).toEqual({A: [ARecords[0]]});
     });
   });
 
@@ -99,7 +101,7 @@ describe('MapStore', () => {
       store.set('example.com', 'A', ARecords);
       store.delete('example.com', 'A', ARecords[0]);
 
-      expect(store.get('example.com', 'A')).toEqual([ARecords[1]]);
+      expect(store.get('example.com', 'A')).toEqual({A: [ARecords[1]]});
     });
 
     it('should be able to delete a whole record', async () => {
@@ -115,8 +117,8 @@ describe('MapStore', () => {
       store.set('example.com', 'AAAA', AAAARecords);
       store.delete('example.com', 'A', ARecords[0]);
 
-      expect(store.get('example.com', 'A')).toEqual([ARecords[1]]);
-      expect(store.get('example.com', 'AAAA')).toEqual(AAAARecords);
+      expect(store.get('example.com', 'A')).toEqual({A: [ARecords[1]]});
+      expect(store.get('example.com', 'AAAA')).toEqual(AAAARecordAnswer);
     });
 
     it('should leave other record types untouched', async () => {
@@ -125,14 +127,14 @@ describe('MapStore', () => {
       store.delete('example.com', 'A');
 
       expect(store.get('example.com', 'A')).toEqual(null);
-      expect(store.get('example.com', 'AAAA')).toEqual(AAAARecords);
+      expect(store.get('example.com', 'AAAA')).toEqual(AAAARecordAnswer);
     });
 
     it('should be able to delete a specific record where its record type does not', async () => {
       store.set('example.com', 'A', ARecords);
       store.delete('example.com', 'AAAA', '::1');
 
-      expect(store.get('example.com', 'A')).toEqual(ARecords);
+      expect(store.get('example.com', 'A')).toEqual(ARecordAnswer);
       expect(store.get('example.com', 'AAAA')).toEqual(null);
     });
 
@@ -144,7 +146,7 @@ describe('MapStore', () => {
     it('should clean up the key if no records are left', async () => {
       store.set('example.com', 'A', ARecords);
       store.delete('example.com', 'A', ARecords[0]);
-      expect(store.get('example.com', 'A')).toEqual([ARecords[1]]);
+      expect(store.get('example.com', 'A')).toEqual({A: [ARecords[1]]});
       store.delete('example.com', 'A', ARecords[1]);
 
       expect(store.get('example.com')).toEqual(null);

--- a/src/plugins/storage/DefaultStore/index.ts
+++ b/src/plugins/storage/DefaultStore/index.ts
@@ -1,4 +1,4 @@
-import { ZoneData, SupportedRecordType, SupportedAnswer } from '../../../types/dns';
+import { ZoneData, SupportedRecordType, SupportedAnswer, DataMap } from '../../../types/dns';
 import { Store } from '../Store';
 import { EventEmitter } from 'events';
 import { DNSRequest, DNSResponse, NextFunction } from '../../../types/server';
@@ -47,16 +47,23 @@ export class DefaultStore extends EventEmitter implements Store {
     domain: string,
     rType?: T,
     wildcards: boolean = true,
-  ): ZoneData[T][] | ZoneData[keyof ZoneData][] | null {
+  ): DataMap | null {
     if (rType) {
       const record = this.data.get(domain);
       if (record && record.size > 0) {
-        return record.get(rType) || null;
+        const records = record.get(rType);
+        if (records) {
+          return {
+            [rType]: records,
+          } as DataMap;
+        }
+        
+        return null;
       }
     } else {
       const record = this.data.get(domain);
       if (record && record.size > 0) {
-        return Array.from(record.values()).flat();
+        return Object.fromEntries(record) as DataMap;
       }
     }
 
@@ -74,12 +81,17 @@ export class DefaultStore extends EventEmitter implements Store {
       if (rType) {
         const record = this.data.get(wildcardDomain);
         if (record && record.size > 0) {
-          return record.get(rType) || null;
+          const records = record.get(rType);
+          if (records) {
+            return {
+              [rType]: records,
+            } as DataMap;
+          }
         }
       } else {
         const record = this.data.get(wildcardDomain);
         if (record && record.size > 0) {
-          return Array.from(record.values()).flat();
+          return Object.fromEntries(record) as DataMap;
         }
       }
     }
@@ -155,19 +167,19 @@ export class DefaultStore extends EventEmitter implements Store {
 
     const records = this.get(name, type);
 
-    const answers: SupportedAnswer[] | undefined = records?.map((record) => {
-      return {
-        name,
-        type,
-        data: record,
-      } as SupportedAnswer;
-    });
-
-    if (records && answers && answers.length > 0) {
-      res.answer(answers);
+    if (records) {
+      res.answer(
+        Object.entries(records).map(([rType, data]) => {
+          return data.map((d) => ({
+            name,
+            type: rType,
+            data: d,
+          } as SupportedAnswer))
+        }).flat(),
+      );
 
       if (this.shouldCache) {
-        this.emitCacheRequest(name, type, records);
+        this.emitCacheRequest(name, type, records[type]);
       }
     }
 

--- a/src/plugins/storage/DefaultStore/index.ts
+++ b/src/plugins/storage/DefaultStore/index.ts
@@ -43,11 +43,7 @@ export class DefaultStore extends EventEmitter implements Store {
    * @param wildcards Whether to resolve wildcard records
    * @returns The data for the given domain and record type, or null if no data is found
    */
-  get<T extends SupportedRecordType>(
-    domain: string,
-    rType?: T,
-    wildcards: boolean = true,
-  ): DataMap | null {
+  get<T extends SupportedRecordType>(domain: string, rType?: T, wildcards: boolean = true): DataMap | null {
     if (rType) {
       const record = this.data.get(domain);
       if (record && record.size > 0) {
@@ -57,7 +53,7 @@ export class DefaultStore extends EventEmitter implements Store {
             [rType]: records,
           } as DataMap;
         }
-        
+
         return null;
       }
     } else {
@@ -169,13 +165,18 @@ export class DefaultStore extends EventEmitter implements Store {
 
     if (records) {
       res.answer(
-        Object.entries(records).map(([rType, data]) => {
-          return data.map((d) => ({
-            name,
-            type: rType,
-            data: d,
-          } as SupportedAnswer))
-        }).flat(),
+        Object.entries(records)
+          .map(([rType, data]) => {
+            return data.map(
+              (d) =>
+                ({
+                  name,
+                  type: rType,
+                  data: d,
+                }) as SupportedAnswer,
+            );
+          })
+          .flat(),
       );
 
       if (this.shouldCache) {

--- a/src/plugins/storage/Store.ts
+++ b/src/plugins/storage/Store.ts
@@ -1,5 +1,5 @@
 import { Handler } from '../../types/server';
-import { ZoneData, SupportedRecordType } from '../../types/dns';
+import { ZoneData, SupportedRecordType, DataMap } from '../../types/dns';
 import { EventEmitter } from 'events';
 import { Awaitable } from '../../common/core/utils';
 
@@ -19,7 +19,7 @@ export abstract class Store extends EventEmitter {
   abstract get<T extends SupportedRecordType>(
     zone: string,
     rType?: T,
-  ): Awaitable<ZoneData[T][] | ZoneData[keyof ZoneData][] | null>;
+  ): Awaitable<DataMap | null>;
 
   /**
    * Set or update information about a zone in the database.

--- a/src/plugins/storage/Store.ts
+++ b/src/plugins/storage/Store.ts
@@ -16,10 +16,7 @@ export abstract class Store extends EventEmitter {
    * @param zone The name of the zone to retrieve
    * @param rType The record type to retrieve. If not provided, all records in the zone should be retrieved.
    */
-  abstract get<T extends SupportedRecordType>(
-    zone: string,
-    rType?: T,
-  ): Awaitable<DataMap | null>;
+  abstract get<T extends SupportedRecordType>(zone: string, rType?: T): Awaitable<DataMap | null>;
 
   /**
    * Set or update information about a zone in the database.

--- a/src/types/dns.ts
+++ b/src/types/dns.ts
@@ -56,7 +56,7 @@ export type ZoneData = {
  */
 export type DataMap = {
   [T in keyof ZoneData]: ZoneData[T][];
-}
+};
 
 export type SupportedAnswer = Exclude<Answer, OptAnswer>;
 export type SupportedRecordType = Exclude<RecordType, 'OPT'>;

--- a/src/types/dns.ts
+++ b/src/types/dns.ts
@@ -49,6 +49,15 @@ export type ZoneData = {
   TXT: TxtData;
 };
 
+/**
+ * Defines a map of all possible data that can be returned in a DNS response.
+ * Each key is a record type, and each value is an array of data associated with
+ * that value.
+ */
+export type DataMap = {
+  [T in keyof ZoneData]: ZoneData[T][];
+}
+
 export type SupportedAnswer = Exclude<Answer, OptAnswer>;
 export type SupportedRecordType = Exclude<RecordType, 'OPT'>;
 export type SupportedQuestion = Question & { type: SupportedRecordType };

--- a/src/types/serverTypes.spec.ts
+++ b/src/types/serverTypes.spec.ts
@@ -35,11 +35,6 @@ describe('PacketWrapper', () => {
 
     for (const rcode of rcodes) {
       const num = RCode[rcode];
-      console.log({
-        rcode,
-        num,
-        last4: packetWrapper.raw.flags! & 0x000f,
-      });
       packetWrapper.rcode = rcode;
       expect(packetWrapper.rcode).toBe(num);
     }

--- a/tests/server.spec.ts
+++ b/tests/server.spec.ts
@@ -1,9 +1,8 @@
 import { DefaultServer } from '../src/common/server';
 import { DNSOverTCP, DNSOverUDP, SupportedNetworkType } from '../src/common/network';
 import { DefaultStore } from '../src/plugins/storage';
-import { PacketWrapper, DNSRequest } from '../src/types';
+import { DNSRequest } from '../src/types';
 import { DuplicateAnswerForRequest } from '../src/types';
-import dns from 'node:dns';
 
 describe('server', () => {
   it('Should log an error when it tries to respond twice to the same request', async () => {

--- a/tests/server.spec.ts
+++ b/tests/server.spec.ts
@@ -7,7 +7,6 @@ import dns from 'node:dns';
 
 describe('server', () => {
   it('Should log an error when it tries to respond twice to the same request', async () => {
-
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const tcp = new DNSOverTCP({ address: 'localhost', port: 8053 });

--- a/tests/server.spec.ts
+++ b/tests/server.spec.ts
@@ -1,15 +1,19 @@
 import { DefaultServer } from '../src/common/server';
-import { DNSOverTCP, DNSOverUDP } from '../src/common/network';
+import { DNSOverTCP, DNSOverUDP, SupportedNetworkType } from '../src/common/network';
 import { DefaultStore } from '../src/plugins/storage';
+import { PacketWrapper, DNSRequest } from '../src/types';
+import { DuplicateAnswerForRequest } from '../src/types';
 import dns from 'node:dns';
 
 describe('server', () => {
-  it('Should throw an error when it tries to respond twice to the same request', async () => {
+  it('Should log an error when it tries to respond twice to the same request', async () => {
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const tcp = new DNSOverTCP({ address: 'localhost', port: 8053 });
+    const udp = new DNSOverUDP({ address: 'localhost', port: 8053 });
     const server = new DefaultServer({
-      networks: [
-        new DNSOverTCP({ address: 'localhost', port: 8053 }),
-        new DNSOverUDP({ address: 'localhost', port: 8053 }),
-      ],
+      networks: [tcp, udp],
       defaultHandler: (req, res) => {
         res.errors.nxDomain();
       },
@@ -60,17 +64,31 @@ describe('server', () => {
       });
     });
 
-    server.start(() => {
-      console.log('Server started');
-    });
+    // mock a DNS request
+    const request = new DNSRequest(
+      {
+        id: 0,
+        questions: [
+          {
+            name: 'example.com',
+            type: 'A',
+            class: 'IN',
+          },
+        ],
+        answers: [],
+        additionals: [],
+        authorities: [],
+      },
+      {
+        remoteAddress: '127.0.0.1',
+        remotePort: 0,
+        type: SupportedNetworkType.TCP,
+      },
+    );
+    const result = await tcp.handler!(request);
+    const records = result.packet.answers.map((answer) => answer.data);
 
-    // query localhost:8053 for example.com
-    const resolver = new dns.promises.Resolver();
-
-    resolver.setServers(['127.0.0.1:8053']);
-
-    const result = await resolver.resolve('example.com');
-
-    expect(result).toEqual(['127.0.0.1']);
+    expect(records).toEqual(['127.0.0.1']);
+    expect(console.error).toHaveBeenCalledWith(expect.any(DuplicateAnswerForRequest));
   });
 });


### PR DESCRIPTION
In the past, storage interfaces returned answers as an array of ZoneData responses. This worked fine for responses to `store.get` calls that specified a data type (i.e. `store.get('example.com', 'A')`), but could produce fairly frustrating to work with responses when getting _all_ records from a zone; the response would merely contain an array of untyped records, leaving the caller to figure out how to determine the record type.

Rather than deal with any messy overrides to retype the response if no rType is passed in, this change instead retypes the `Store#get` method to simply return an object of the form
```
{
    "A": ["127.0.0.1"],
    "AAAA": ["::1"],
    ...
}
```
for each record type that contains records.

### Key Changes:

#### DNS Record Handling Enhancements:
* Updated the `get` method in `DefaultStore` to return a `DataMap` instead of an array of records. This change ensures a more structured and consistent return type for DNS records. [[1]](diffhunk://#diff-0fbb8f50fac098eff297ba41cf60b26d9d9d3ce30967008210e847b13426629dL46-R62) [[2]](diffhunk://#diff-0fbb8f50fac098eff297ba41cf60b26d9d9d3ce30967008210e847b13426629dL77-R90)
* Introduced the `DataMap` type in `dns.ts` to define a map of all possible data that can be returned in a DNS response.

#### Test Case Updates:
* Modified test cases in `defaultStore.spec.ts` to validate the new `DataMap` structure instead of arrays. This includes changes to assertions to check for the correct format of returned DNS records. [[1]](diffhunk://#diff-aa196e8521ed6336b004dbb6deda968881e728c82318553d0eba0286f1db269cL25-R30) [[2]](diffhunk://#diff-aa196e8521ed6336b004dbb6deda968881e728c82318553d0eba0286f1db269cL41-R46) [[3]](diffhunk://#diff-aa196e8521ed6336b004dbb6deda968881e728c82318553d0eba0286f1db269cL58-R66) [[4]](diffhunk://#diff-aa196e8521ed6336b004dbb6deda968881e728c82318553d0eba0286f1db269cL73-R88) [[5]](diffhunk://#diff-aa196e8521ed6336b004dbb6deda968881e728c82318553d0eba0286f1db269cL102-R104) [[6]](diffhunk://#diff-aa196e8521ed6336b004dbb6deda968881e728c82318553d0eba0286f1db269cL118-R121) [[7]](diffhunk://#diff-aa196e8521ed6336b004dbb6deda968881e728c82318553d0eba0286f1db269cL128-R137) [[8]](diffhunk://#diff-aa196e8521ed6336b004dbb6deda968881e728c82318553d0eba0286f1db269cL147-R149)
* Added new constants `ARecordAnswer` and `AAAARecordAnswer` in `defaultStore.spec.ts` to match the new `DataMap` structure.

#### Server Unit Test Improvements:
* Changed the server unit tests to mock a network request rather than actually binding, and to mock `console.error` to specifically check for the presence of errors when responding twice to the same DNS request. [[1]](diffhunk://#diff-0a5904d46dc9c0a7fc2c463bd354aea07d29af1a7c2468caf2a5d8f4831ca54fL2-R14) [[2]](diffhunk://#diff-0a5904d46dc9c0a7fc2c463bd354aea07d29af1a7c2468caf2a5d8f4831ca54fL63-R90)

#### Code Cleanup:
* Removed unnecessary console logs from `serverTypes.spec.ts` to clean up the test output.