### PR TITLE
Fix UDP not being able to bind over ipv6

### DIFF
--- a/src/common/network/udp.ts
+++ b/src/common/network/udp.ts
@@ -4,6 +4,7 @@ import dgram from 'dgram';
 import dnsPacket, { TRUNCATED_RESPONSE } from 'dns-packet';
 import { RCode, CombineFlags } from '../core/utils';
 import { DNSRequest } from '../../types';
+import { isIPv6 } from 'net';
 
 /**
  * Serializer for the UDP protocol. The `dns-packet` module's
@@ -71,7 +72,7 @@ export class DNSOverUDP implements Network<dnsPacket.Packet> {
   constructor({ address, port, serializer }: DNSOverUDPProps) {
     this.address = address;
     this.port = port;
-    this.server = dgram.createSocket('udp4');
+    this.server = dgram.createSocket(isIPv6(this.address) ? 'udp6' : 'udp4');
     this.serializer = serializer || new UDPSerializer();
 
     this.server.on('message', async (msg, rinfo) => {


### PR DESCRIPTION
This pull request includes changes to the `src/common/network/udp.ts` file to improve the handling of IPv6 addresses in the DNS over UDP implementation. The most important changes include importing the `isIPv6` function from the `net` module and modifying the `DNSOverUDP` class to dynamically create the appropriate type of UDP socket based on the IP address version.

Improvements to IPv6 handling:

* [`src/common/network/udp.ts`](diffhunk://#diff-1a1c89d34ae3a05a6e88d1aa732d400d1aa84f3a7471e465486bc536c4db0ee8R7): Imported the `isIPv6` function from the `net` module to facilitate the detection of IPv6 addresses.
* [`src/common/network/udp.ts`](diffhunk://#diff-1a1c89d34ae3a05a6e88d1aa732d400d1aa84f3a7471e465486bc536c4db0ee8L74-R75): Modified the `DNSOverUDP` class to create a UDP socket using `udp6` if the provided address is IPv6, otherwise it uses `udp4`.